### PR TITLE
Fix addNoteOfType and deleteNote behavior

### DIFF
--- a/app/src/main/java/com/example/cahier/ui/CahierHomeScreen.kt
+++ b/app/src/main/java/com/example/cahier/ui/CahierHomeScreen.kt
@@ -21,7 +21,6 @@ package com.example.cahier.ui
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
-import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.annotation.StringRes
@@ -174,8 +173,8 @@ fun HomePane(
                                         homeScreenViewModel.selectNote(it.id)
                                     },
                                     onAddNewTextNote = {
-                                        homeScreenViewModel.addNote { it ->
-                                            navigateToCanvas(it)
+                                        homeScreenViewModel.addNote { noteId ->
+                                            navigateToCanvas(noteId)
                                         }
                                     },
                                     onAddNewDrawingNote = {
@@ -184,7 +183,7 @@ fun HomePane(
                                         }
                                     },
                                     onDeleteNote = { note ->
-                                        homeScreenViewModel.deleteNote()
+                                        homeScreenViewModel.deleteNote(note)
                                         navigateUp()
                                     },
                                     onToggleFavorite = { noteId ->
@@ -224,7 +223,6 @@ fun HomePane(
         )
     }
 }
-
 
 
 @Composable


### PR DESCRIPTION
### Fix `addNoteOfType` return value and `deleteNote` behavior

This PR corrects two issues in the vm/repository layer:

1. **`addNoteOfType`** was returning the `newlyAddedId` property immediately before the coroutine-driven insert had completed. So it always yielded the default `0` value instead of the actual ID assigned by Room. 
It also mixed a callback and a non-null `Long` return, leading callers to navigate to a “-1” page on failure. Now we use a nullable `Long?` return, drop the callback, and simply skip navigation when the result is `null`, avoiding the “-1” render error. 
2. **`deleteNote`** was erroneously deleting the note stored in `_uiState` instead of the specific note passed in.

|now|before|
|-|-|
|<video src="https://github.com/user-attachments/assets/b0a81586-b9a2-40c0-8f43-10b374c93e51" />|<video src="https://github.com/user-attachments/assets/d5eac085-bdcf-45f9-9b06-1cb610fe262b" />|




