### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build cahier
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build debug app
+        run: ./gradlew :app:assembleDebug


### PR DESCRIPTION
This commit adds a build workflow for the cahier sample. The workflow is triggered on push, pull request, and manual workflow dispatch. It performs the following steps:

- Checks out the code
- Sets up JDK 17
- Sets up Gradle
- Makes gradlew executable
- Builds the debug app