### PR TITLE
chore: use `IntentCompat` instead of explicit deprecated api

### DIFF
--- a/app/src/main/java/com/example/cahier/MainActivity.kt
+++ b/app/src/main/java/com/example/cahier/MainActivity.kt
@@ -18,7 +18,6 @@
 
 package com.example.cahier
 
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -27,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.core.content.IntentCompat
 import com.example.cahier.data.NoteType
 import com.example.cahier.ui.CahierApp
 import com.example.cahier.ui.theme.CahierAppTheme
@@ -39,15 +39,11 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         val noteId = intent.getLongExtra(AppArgs.NOTE_ID_KEY, -1)
-        val noteType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra(AppArgs.NOTE_TYPE_KEY, NoteType::class.java)
-        }
-        else {
-            // The old way to get the parcelable extra is deprecated as of API 33, but we use it
-            // because we need to support older versions of Android.
-            @Suppress("DEPRECATION")
-            intent.getParcelableExtra(AppArgs.NOTE_TYPE_KEY) as NoteType?
-        }
+        val noteType = IntentCompat.getParcelableExtra(
+            intent,
+            AppArgs.NOTE_TYPE_KEY,
+            NoteType::class.java
+        )
 
         setContent {
             CahierAppTheme {


### PR DESCRIPTION
## Issue

Hello, maintainers! Thanks for making a new fancy sample application.

While reviewing the code, I noticed that a deprecated API was being used. Since `IntentCompat.getParcelableExtra` can be used as a replacement, I updated the code accordingly.
