### PR TITLE
feat: add custom brush loading from database

### DIFF
--- a/app/src/androidTest/java/com/example/cahier/features/drawing/viewmodel/DrawingCanvasViewModelTest.kt
+++ b/app/src/androidTest/java/com/example/cahier/features/drawing/viewmodel/DrawingCanvasViewModelTest.kt
@@ -35,6 +35,8 @@ import coil3.ImageLoader
 import com.example.cahier.core.data.FakeNotesRepository
 import com.example.cahier.core.navigation.DrawingCanvasDestination
 import com.example.cahier.core.utils.FileHelper
+import com.example.cahier.developer.brushdesigner.data.CustomBrushDao
+import com.example.cahier.developer.brushdesigner.data.CustomBrushEntity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.Dispatchers
@@ -49,6 +51,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -90,7 +94,8 @@ class DrawingCanvasViewModelTest {
         )
         val context = ApplicationProvider.getApplicationContext<Context>()
         viewModel = DrawingCanvasViewModel(
-            context, savedStateHandle, notesRepository, fileHelper, imageLoader
+            context, savedStateHandle, notesRepository, fileHelper, imageLoader,
+            customBrushDao = FakeCustomBrushDao()
         )
     }
 
@@ -212,4 +217,10 @@ class DrawingCanvasViewModelTest {
             viewModel.isEraserMode.value
         )
     }
+}
+
+private class FakeCustomBrushDao : CustomBrushDao {
+    override fun getAllCustomBrushes(): Flow<List<CustomBrushEntity>> = flowOf(emptyList())
+    override suspend fun saveCustomBrush(brush: CustomBrushEntity) {}
+    override suspend fun deleteCustomBrush(name: String) {}
 }

--- a/app/src/main/java/com/example/cahier/core/ui/CahierTextureBitmapStore.kt
+++ b/app/src/main/java/com/example/cahier/core/ui/CahierTextureBitmapStore.kt
@@ -33,4 +33,9 @@ class CahierTextureBitmapStore(context: Context) : TextureBitmapStore {
         return BitmapFactory.decodeResource(resources, drawable)
             ?: throw IllegalStateException("Could not load bitmap for resource $drawable")
     }
+
+    fun loadTexture(textureId: String, bitmap: Bitmap) {
+        val id = getShortName(textureId)
+        loadedBitmaps[id] = bitmap
+    }
 }

--- a/app/src/main/java/com/example/cahier/features/drawing/viewmodel/DrawingCanvasViewModel.kt
+++ b/app/src/main/java/com/example/cahier/features/drawing/viewmodel/DrawingCanvasViewModel.kt
@@ -20,8 +20,10 @@ package com.example.cahier.features.drawing.viewmodel
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.net.Uri
+import android.util.Log
 import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.graphics.Color
@@ -29,6 +31,7 @@ import androidx.core.graphics.createBitmap
 import androidx.core.net.toUri
 import androidx.ink.brush.Brush
 import androidx.ink.brush.BrushFamily
+import androidx.ink.brush.ExperimentalInkCustomBrushApi
 import androidx.ink.brush.StockBrushes
 import androidx.ink.brush.compose.composeColor
 import androidx.ink.brush.compose.copyWithComposeColor
@@ -39,6 +42,7 @@ import androidx.ink.geometry.MutableParallelogram
 import androidx.ink.geometry.MutableSegment
 import androidx.ink.geometry.MutableVec
 import androidx.ink.rendering.android.canvas.CanvasStrokeRenderer
+import androidx.ink.storage.decode
 import androidx.ink.strokes.Stroke
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -52,16 +56,21 @@ import com.example.cahier.core.data.NotesRepository
 import com.example.cahier.core.navigation.DrawingCanvasDestination
 import com.example.cahier.core.ui.CahierTextureBitmapStore
 import com.example.cahier.core.ui.CahierUiState
+import com.example.cahier.developer.brushdesigner.data.CustomBrushDao
 import com.example.cahier.features.drawing.CustomBrushes
 import com.example.cahier.core.utils.FileHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
 import javax.inject.Inject
 
 @HiltViewModel
@@ -70,7 +79,8 @@ class DrawingCanvasViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val noteRepository: NotesRepository,
     val fileHelper: FileHelper,
-    private val imageLoader: ImageLoader
+    private val imageLoader: ImageLoader,
+    private val customBrushDao: CustomBrushDao,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CahierUiState())
@@ -113,6 +123,8 @@ class DrawingCanvasViewModel @Inject constructor(
     val customBrushes: StateFlow<List<CustomBrush>> = _customBrushes.asStateFlow()
 
     private var isBrushSelectedInSession = false
+
+    val textureStore = CahierTextureBitmapStore(context)
 
     init {
         viewModelScope.launch {
@@ -443,9 +455,47 @@ class DrawingCanvasViewModel @Inject constructor(
         return _selectedBrush.value
     }
 
+    @OptIn(ExperimentalInkCustomBrushApi::class)
     private fun loadCustomBrushes() {
-        viewModelScope.launch {
-            _customBrushes.value = CustomBrushes.getBrushes(context)
+        viewModelScope.launch(Dispatchers.IO) {
+            val builtInBrushes = CustomBrushes.getBrushes(context)
+
+            customBrushDao.getAllCustomBrushes().collect { dbBrushes ->
+                val userBrushes = dbBrushes.mapNotNull { entity ->
+                    try {
+                        val gzippedInputStream =
+                            GZIPInputStream(ByteArrayInputStream(entity.brushBytes))
+                        val rawProtoBytes = gzippedInputStream.readBytes()
+                        val proto = ink.proto.BrushFamily.parseFrom(rawProtoBytes)
+
+                        proto.textureIdToBitmapMap.forEach { (id, byteString) ->
+                            val bitmapBytes = byteString.toByteArray()
+                            val bitmap =
+                                BitmapFactory.decodeByteArray(bitmapBytes, 0, bitmapBytes.size)
+                            if (bitmap != null) {
+                                textureStore.loadTexture(id, bitmap)
+                            }
+                        }
+
+                        ByteArrayInputStream(entity.brushBytes).use { inputStream ->
+                            val family = BrushFamily.decode(inputStream)
+                            CustomBrush(
+                                name = entity.name,
+                                icon = com.example.cahier.R.drawable.edit_24px,
+                                brushFamily = family,
+                                isRemovable = true
+                            )
+                        }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error loading textures/brush ${entity.name}", e)
+                        null
+                    }
+                }
+
+                withContext(Dispatchers.Main) {
+                    _customBrushes.value = builtInBrushes + userBrushes
+                }
+            }
         }
     }
 

--- a/app/src/main/res/drawable/edit_24px.xml
+++ b/app/src/main/res/drawable/edit_24px.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M200,760L257,760L648,369L591,312L200,703L200,760ZM120,840L120,670L648,143Q660,132 674.5,126Q689,120 705,120Q721,120 736,126Q751,132 762,144L817,200Q829,211 834.5,226Q840,241 840,256Q840,272 834.5,286.5Q829,301 817,313L290,840L120,840ZM760,256L760,256L704,200L704,200L760,256ZM619,341L591,312L591,312L648,369L648,369L619,341Z"/>
+</vector>


### PR DESCRIPTION
- CahierTextureBitmapStore: add loadTexture() for programmatic bitmap loading
- DrawingCanvasViewModel: inject CustomBrushDao, add textureStore field,
      upgrade loadCustomBrushes() to decode brushes from DB
      (gzip → proto → texture extraction → BrushFamily.decode)
- DrawingCanvasViewModelTest: add FakeCustomBrushDao (prefer