### PR TITLE
[BrushGraph 5/7] Add complex node fields

### DIFF
--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/BehaviorNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/BehaviorNodeFields.kt
@@ -1,0 +1,236 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.cahier.R
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import com.example.cahier.developer.brushgraph.ui.fields.NODE_TYPES_START
+import com.example.cahier.developer.brushgraph.ui.fields.NODE_TYPES_OPERATOR
+import com.example.cahier.developer.brushgraph.ui.fields.NODE_TYPES_TERMINAL
+import ink.proto.BrushBehavior as ProtoBrushBehavior
+
+@Composable
+fun BehaviorNodeFields(
+  data: NodeData.Behavior,
+  onUpdate: (NodeData) -> Unit,
+  onDropdownEditComplete: () -> Unit,
+  onFieldEditComplete: () -> Unit,
+  textFieldsLocked: Boolean,
+  modifier: Modifier = Modifier
+) {
+  val behaviorNode = data.node
+  val nodeCase = behaviorNode.nodeCase
+  var expandedNodeTypes by remember { mutableStateOf(false) }
+
+  Column(modifier = modifier) {
+    // Node Type Selector
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.fillMaxWidth()
+    ) {
+      ExposedDropdownMenuBox(
+        expanded = expandedNodeTypes,
+        onExpandedChange = { expandedNodeTypes = it },
+        modifier = Modifier.weight(1f)
+      ) {
+        OutlinedTextField(
+          value = stringResource(nodeCase.displayStringRId()),
+          onValueChange = {},
+          readOnly = true,
+          label = { Text(stringResource(R.string.bg_node_type)) },
+          trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedNodeTypes) },
+          modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+          expanded = expandedNodeTypes,
+          onDismissRequest = { expandedNodeTypes = false }
+        ) {
+          @Composable
+          fun DropdownSection(label: String, types: List<ProtoBrushBehavior.Node.NodeCase>) {
+            Row(
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+            ) {
+              HorizontalDivider(modifier = Modifier.weight(1f))
+              Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+                modifier = Modifier.padding(horizontal = 8.dp)
+              )
+              HorizontalDivider(modifier = Modifier.weight(1f))
+            }
+            types.forEach { type ->
+              DropdownMenuItem(
+                text = { Text(stringResource(type.displayStringRId())) },
+                onClick = {
+                  if (type != nodeCase) {
+                    onUpdate(createDefaultNode(type))
+                    onDropdownEditComplete()
+                  }
+                  expandedNodeTypes = false
+                }
+              )
+            }
+          }
+
+          DropdownSection(stringResource(R.string.bg_section_start_nodes), NODE_TYPES_START)
+          DropdownSection(stringResource(R.string.bg_section_operator_nodes), NODE_TYPES_OPERATOR)
+          DropdownSection(stringResource(R.string.bg_section_terminal_nodes), NODE_TYPES_TERMINAL)
+        }
+      }
+    }
+
+    // Developer Comment
+    if (nodeCase == ProtoBrushBehavior.Node.NodeCase.TARGET_NODE ||
+        nodeCase == ProtoBrushBehavior.Node.NodeCase.POLAR_TARGET_NODE) {
+      OutlinedTextField(
+        value = data.developerComment,
+        onValueChange = {
+          onUpdate(data.copy(developerComment = it))
+        },
+        label = { Text(stringResource(R.string.bg_developer_comment)) },
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        minLines = 2,
+        enabled = !textFieldsLocked,
+      )
+    }
+
+    // Dispatch to specific node fields
+    when (nodeCase) {
+      ProtoBrushBehavior.Node.NodeCase.SOURCE_NODE -> {
+        SourceNodeFields(
+          sourceNode = behaviorNode.sourceNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate,
+          onDropdownEditComplete = onDropdownEditComplete,
+          onFieldEditComplete = onFieldEditComplete,
+          textFieldsLocked = textFieldsLocked
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.CONSTANT_NODE -> {
+        ConstantNodeFields(
+          constantNode = behaviorNode.constantNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate,
+          onFieldEditComplete = onFieldEditComplete
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.NOISE_NODE -> {
+        NoiseNodeFields(
+          noiseNode = behaviorNode.noiseNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate,
+          onFieldEditComplete = onFieldEditComplete,
+          onDropdownEditComplete = onDropdownEditComplete,
+          textFieldsLocked = textFieldsLocked
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.TOOL_TYPE_FILTER_NODE -> {
+        ToolTypeFilterNodeFields(
+          filterNode = behaviorNode.toolTypeFilterNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.DAMPING_NODE -> {
+        DampingNodeFields(
+          dampingNode = behaviorNode.dampingNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate,
+          onFieldEditComplete = onFieldEditComplete,
+          onDropdownEditComplete = onDropdownEditComplete
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.RESPONSE_NODE -> {
+        ResponseNodeFields(
+          responseNode = behaviorNode.responseNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.INTEGRAL_NODE -> {
+        IntegralNodeFields(
+          integralNode = behaviorNode.integralNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate,
+          onFieldEditComplete = onFieldEditComplete,
+          onDropdownEditComplete = onDropdownEditComplete
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.BINARY_OP_NODE -> {
+        BinaryOpNodeFields(
+          binaryNode = behaviorNode.binaryOpNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate,
+          onDropdownEditComplete = onDropdownEditComplete
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.INTERPOLATION_NODE -> {
+        InterpolationNodeFields(
+          interpNode = behaviorNode.interpolationNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.TARGET_NODE -> {
+        TargetNodeFields(
+          targetNode = behaviorNode.targetNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate,
+          onFieldEditComplete = onFieldEditComplete,
+          onDropdownEditComplete = onDropdownEditComplete
+        )
+      }
+      ProtoBrushBehavior.Node.NodeCase.POLAR_TARGET_NODE -> {
+        PolarTargetNodeFields(
+          polarNode = behaviorNode.polarTargetNode,
+          behaviorNode = behaviorNode,
+          onUpdate = onUpdate,
+          onFieldEditComplete = onFieldEditComplete,
+          onDropdownEditComplete = onDropdownEditComplete
+        )
+      }
+      else -> {
+        // Fallback or empty view for unsupported nodes
+        Text(stringResource(R.string.bg_err_unsupported_behavior_node_type, nodeCase.toString()))
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/BehaviorNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/BehaviorNodeFields.kt
@@ -82,10 +82,14 @@ fun BehaviorNodeFields(
           onDismissRequest = { expandedNodeTypes = false }
         ) {
           @Composable
-          fun DropdownSection(label: String, types: List<ProtoBrushBehavior.Node.NodeCase>) {
+          fun DropdownSection(
+            label: String,
+            types: List<ProtoBrushBehavior.Node.NodeCase>,
+            modifier: Modifier = Modifier
+          ) {
             Row(
               verticalAlignment = Alignment.CenterVertically,
-              modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+              modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)
             ) {
               HorizontalDivider(modifier = Modifier.weight(1f))
               Text(

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ColorFunctionNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ColorFunctionNodeFields.kt
@@ -17,6 +17,7 @@
 
 package com.example.cahier.developer.brushgraph.ui.fields
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -59,90 +60,91 @@ fun ColorFunctionNodeFields(
     R.string.bg_replace_color
   }
 
-  FieldWithTooltip(
-    tooltipTitle = stringResource(R.string.bg_title_function_type_format, stringResource(currentTypeResId)),
-    tooltipText = stringResource(getColorFunctionTooltip(currentTypeResId)),
-    modifier = modifier
-  ) {
-    EnumDropdown(
-      label = stringResource(R.string.bg_function_type),
-      currentValue = currentTypeResId,
-      values = listOf(R.string.bg_opacity_multiplier, R.string.bg_replace_color),
-      displayName = { stringResource(it) },
-      onSelected = { resId ->
-        if (resId != currentTypeResId) {
-          onUpdate(
-            if (resId == R.string.bg_opacity_multiplier) {
-              NodeData.ColorFunction(
-                ProtoColorFunction.newBuilder().setOpacityMultiplier(1f).build()
-              )
-            } else {
-              NodeData.ColorFunction(
-                ProtoColorFunction.newBuilder()
-                  .setReplaceColor(
-                    ProtoColor.newBuilder()
-                      .setRed(0f)
-                      .setGreen(0f)
-                      .setBlue(0f)
-                      .setAlpha(1f)
-                      .build()
-                  )
-                  .build()
-              )
-            }
-          )
-        }
-        onDropdownEditComplete()
-      }
-    )
-  }
-  
-  if (function.hasOpacityMultiplier()) {
-    NumericField(
-      title = stringResource(R.string.bg_label_opacity_multiplier),
-      value = function.opacityMultiplier,
-      limits = NumericLimits(0f, 2f, 0.01f),
-      onValueChanged = { onUpdate(NodeData.ColorFunction(function.toBuilder().setOpacityMultiplier(it).build())) },
-      onValueChangeFinished = onFieldEditComplete
-    )
-  } else if (function.hasReplaceColor()) {
-    val color = function.replaceColor
-    val composeColor =
-      Color(red = color.red, green = color.green, blue = color.blue, alpha = color.alpha)
-    Row(
-      verticalAlignment = Alignment.CenterVertically,
-      modifier = Modifier.padding(vertical = 8.dp)
+  Column(modifier = modifier) {
+    FieldWithTooltip(
+      tooltipTitle = stringResource(R.string.bg_title_function_type_format, stringResource(currentTypeResId)),
+      tooltipText = stringResource(getColorFunctionTooltip(currentTypeResId)),
     ) {
-      Text(stringResource(R.string.bg_color_label), style = MaterialTheme.typography.bodyMedium)
-      Surface(
-        onClick = {
-          onChooseColor(composeColor) { newColor ->
+      EnumDropdown(
+        label = stringResource(R.string.bg_function_type),
+        currentValue = currentTypeResId,
+        values = listOf(R.string.bg_opacity_multiplier, R.string.bg_replace_color),
+        displayName = { stringResource(it) },
+        onSelected = { resId ->
+          if (resId != currentTypeResId) {
             onUpdate(
-              NodeData.ColorFunction(
-                function.toBuilder()
-                  .setReplaceColor(
-                    ProtoColor.newBuilder()
-                      .setRed(newColor.red)
-                      .setGreen(newColor.green)
-                      .setBlue(newColor.blue)
-                      .setAlpha(newColor.alpha)
-                      .build()
-                  )
-                  .build()
-              )
+              if (resId == R.string.bg_opacity_multiplier) {
+                NodeData.ColorFunction(
+                  ProtoColorFunction.newBuilder().setOpacityMultiplier(1f).build()
+                )
+              } else {
+                NodeData.ColorFunction(
+                  ProtoColorFunction.newBuilder()
+                    .setReplaceColor(
+                      ProtoColor.newBuilder()
+                        .setRed(0f)
+                        .setGreen(0f)
+                        .setBlue(0f)
+                        .setAlpha(1f)
+                        .build()
+                    )
+                    .build()
+                )
+              }
             )
           }
-        },
-        shape = RoundedCornerShape(4.dp),
-        color = composeColor,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-        modifier = Modifier.size(40.dp)
-      ) {}
-      Spacer(Modifier.width(8.dp))
-      Text(
-        text = String.format("ARGB #%08X", (composeColor.toArgb())),
-        style = MaterialTheme.typography.bodySmall,
+          onDropdownEditComplete()
+        }
       )
+    }
+    
+    if (function.hasOpacityMultiplier()) {
+      NumericField(
+        title = stringResource(R.string.bg_label_opacity_multiplier),
+        value = function.opacityMultiplier,
+        limits = NumericLimits(0f, 2f, 0.01f),
+        onValueChanged = { onUpdate(NodeData.ColorFunction(function.toBuilder().setOpacityMultiplier(it).build())) },
+        onValueChangeFinished = onFieldEditComplete
+      )
+    } else if (function.hasReplaceColor()) {
+      val color = function.replaceColor
+      val composeColor =
+        Color(red = color.red, green = color.green, blue = color.blue, alpha = color.alpha)
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(vertical = 8.dp)
+      ) {
+        Text(stringResource(R.string.bg_color_label), style = MaterialTheme.typography.bodyMedium)
+        Surface(
+          onClick = {
+            onChooseColor(composeColor) { newColor ->
+              onUpdate(
+                NodeData.ColorFunction(
+                  function.toBuilder()
+                    .setReplaceColor(
+                      ProtoColor.newBuilder()
+                        .setRed(newColor.red)
+                        .setGreen(newColor.green)
+                        .setBlue(newColor.blue)
+                        .setAlpha(newColor.alpha)
+                        .build()
+                    )
+                    .build()
+                )
+              )
+            }
+          },
+          shape = RoundedCornerShape(4.dp),
+          color = composeColor,
+          border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+          modifier = Modifier.size(40.dp)
+        ) {}
+        Spacer(Modifier.width(8.dp))
+        Text(
+          text = String.format("ARGB #%08X", (composeColor.toArgb())),
+          style = MaterialTheme.typography.bodySmall,
+        )
+      }
     }
   }
 }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ColorFunctionNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ColorFunctionNodeFields.kt
@@ -1,0 +1,148 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import ink.proto.Color as ProtoColor
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.cahier.R
+import com.example.cahier.developer.brushdesigner.ui.NumericField
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import com.example.cahier.developer.brushdesigner.ui.EnumDropdown
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.ui.FieldWithTooltip
+import com.example.cahier.developer.brushgraph.ui.getColorFunctionTooltip
+import ink.proto.ColorFunction as ProtoColorFunction
+
+@Composable
+fun ColorFunctionNodeFields(
+  function: ProtoColorFunction,
+  onUpdate: (NodeData) -> Unit,
+  onChooseColor: (Color, (Color) -> Unit) -> Unit,
+  onDropdownEditComplete: () -> Unit,
+  onFieldEditComplete: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  val currentTypeResId = if (function.hasOpacityMultiplier()) {
+    R.string.bg_opacity_multiplier
+  } else {
+    R.string.bg_replace_color
+  }
+
+  FieldWithTooltip(
+    tooltipTitle = stringResource(R.string.bg_title_function_type_format, stringResource(currentTypeResId)),
+    tooltipText = stringResource(getColorFunctionTooltip(currentTypeResId)),
+    modifier = modifier
+  ) {
+    EnumDropdown(
+      label = stringResource(R.string.bg_function_type),
+      currentValue = currentTypeResId,
+      values = listOf(R.string.bg_opacity_multiplier, R.string.bg_replace_color),
+      displayName = { stringResource(it) },
+      onSelected = { resId ->
+        if (resId != currentTypeResId) {
+          onUpdate(
+            if (resId == R.string.bg_opacity_multiplier) {
+              NodeData.ColorFunction(
+                ProtoColorFunction.newBuilder().setOpacityMultiplier(1f).build()
+              )
+            } else {
+              NodeData.ColorFunction(
+                ProtoColorFunction.newBuilder()
+                  .setReplaceColor(
+                    ProtoColor.newBuilder()
+                      .setRed(0f)
+                      .setGreen(0f)
+                      .setBlue(0f)
+                      .setAlpha(1f)
+                      .build()
+                  )
+                  .build()
+              )
+            }
+          )
+        }
+        onDropdownEditComplete()
+      }
+    )
+  }
+  
+  if (function.hasOpacityMultiplier()) {
+    NumericField(
+      title = stringResource(R.string.bg_label_opacity_multiplier),
+      value = function.opacityMultiplier,
+      limits = NumericLimits.standard(0f, 2f, 0.01f),
+      onValueChanged = { onUpdate(NodeData.ColorFunction(function.toBuilder().setOpacityMultiplier(it).build())) },
+      onValueChangeFinished = onFieldEditComplete
+    )
+  } else if (function.hasReplaceColor()) {
+    val color = function.replaceColor
+    val composeColor =
+      Color(red = color.red, green = color.green, blue = color.blue, alpha = color.alpha)
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.padding(vertical = 8.dp)
+    ) {
+      Text(stringResource(R.string.bg_color_label), style = MaterialTheme.typography.bodyMedium)
+      Surface(
+        onClick = {
+          onChooseColor(composeColor) { newColor ->
+            onUpdate(
+              NodeData.ColorFunction(
+                function.toBuilder()
+                  .setReplaceColor(
+                    ProtoColor.newBuilder()
+                      .setRed(newColor.red)
+                      .setGreen(newColor.green)
+                      .setBlue(newColor.blue)
+                      .setAlpha(newColor.alpha)
+                      .build()
+                  )
+                  .build()
+              )
+            )
+          }
+        },
+        shape = RoundedCornerShape(4.dp),
+        color = composeColor,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        modifier = Modifier.size(40.dp)
+      ) {}
+      Spacer(Modifier.width(8.dp))
+      Text(
+        text = String.format("ARGB #%08X", (composeColor.toArgb())),
+        style = MaterialTheme.typography.bodySmall,
+      )
+    }
+  }
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ColorFunctionNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ColorFunctionNodeFields.kt
@@ -101,7 +101,7 @@ fun ColorFunctionNodeFields(
     NumericField(
       title = stringResource(R.string.bg_label_opacity_multiplier),
       value = function.opacityMultiplier,
-      limits = NumericLimits.standard(0f, 2f, 0.01f),
+      limits = NumericLimits(0f, 2f, 0.01f),
       onValueChanged = { onUpdate(NodeData.ColorFunction(function.toBuilder().setOpacityMultiplier(it).build())) },
       onValueChangeFinished = onFieldEditComplete
     )

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
@@ -70,15 +70,15 @@ fun FamilyNodeFields(
     EnumDropdown(
       label = stringResource(R.string.bg_input_model),
       currentValue = data.inputModel.displayStringRId(),
-      values = listOf(R.string.bg_model_sliding_window, R.string.bg_model_spring, R.string.bg_model_naive_experimental),
+      values = listOf(R.string.bg_model_sliding_window, R.string.bg_model_passthrough),
       displayName = { stringResource(it) },
       onSelected = { modelResId ->
         val newModel =
           when (modelResId) {
-            R.string.bg_model_naive_experimental ->
+            R.string.bg_model_passthrough ->
               ProtoBrushFamily.InputModel.newBuilder()
-                .setExperimentalNaiveModel(
-                  ProtoBrushFamily.ExperimentalNaiveModel.getDefaultInstance()
+                .setPassthroughModel(
+                  ProtoBrushFamily.PassthroughModel.getDefaultInstance()
                 )
                 .build()
             R.string.bg_model_sliding_window ->
@@ -89,13 +89,13 @@ fun FamilyNodeFields(
                     .setExperimentalUpsamplingPeriodSeconds(0.005f)
                 )
                 .build()
-            R.string.bg_model_spring ->
-              ProtoBrushFamily.InputModel.newBuilder()
-                .setSpringModel(ProtoBrushFamily.SpringModel.getDefaultInstance())
-                .build()
             else ->
               ProtoBrushFamily.InputModel.newBuilder()
-                .setSpringModel(ProtoBrushFamily.SpringModel.getDefaultInstance())
+                .setSlidingWindowModel(
+                  ProtoBrushFamily.SlidingWindowModel.newBuilder()
+                    .setWindowSizeSeconds(0.02f)
+                    .setExperimentalUpsamplingPeriodSeconds(0.005f)
+                )
                 .build()
           }
         onUpdate(data.copy(inputModel = newModel))
@@ -105,7 +105,7 @@ fun FamilyNodeFields(
   }
   
   val inputModel = data.inputModel
-  if (inputModel.hasSlidingWindowModel() || (!inputModel.hasSpringModel() && !inputModel.hasExperimentalNaiveModel())) {
+  if (inputModel.hasSlidingWindowModel() || !inputModel.hasPassthroughModel()) {
     val swModel = inputModel.slidingWindowModel
     val windowMs = if (swModel.hasWindowSizeSeconds()) (swModel.windowSizeSeconds * 1000).toLong() else 20L
     val upsamplingHz = if (swModel.hasExperimentalUpsamplingPeriodSeconds()) {

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
@@ -1,0 +1,151 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.cahier.R
+import com.example.cahier.developer.brushdesigner.ui.EnumDropdown
+import com.example.cahier.developer.brushdesigner.ui.NumericField
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.ui.FieldWithTooltip
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import com.example.cahier.developer.brushgraph.ui.getInputModelTooltip
+import ink.proto.BrushFamily as ProtoBrushFamily
+
+@Composable
+fun FamilyNodeFields(
+  data: NodeData.Family,
+  onUpdate: (NodeData) -> Unit,
+  onDropdownEditComplete: () -> Unit,
+  textFieldsLocked: Boolean,
+  modifier: Modifier = Modifier
+) {
+  val context = LocalContext.current
+  
+  OutlinedTextField(
+    value = data.clientBrushFamilyId,
+    onValueChange = { onUpdate(data.copy(clientBrushFamilyId = it)) },
+    label = { Text(stringResource(R.string.bg_client_brush_family_id)) },
+    modifier = modifier.fillMaxWidth().padding(vertical = 4.dp),
+    singleLine = true,
+    enabled = !textFieldsLocked,
+  )
+  OutlinedTextField(
+    value = data.developerComment,
+    onValueChange = { onUpdate(data.copy(developerComment = it)) },
+    label = { Text(stringResource(R.string.bg_brush_developer_comment)) },
+    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+    minLines = 3,
+    enabled = !textFieldsLocked,
+  )
+  
+  FieldWithTooltip(
+    tooltipTitle = stringResource(R.string.bg_title_input_model_format, stringResource(data.inputModel.displayStringRId())),
+    tooltipText = stringResource(getInputModelTooltip(data.inputModel.displayStringRId()))
+  ) {
+    EnumDropdown(
+      label = stringResource(R.string.bg_input_model),
+      currentValue = data.inputModel.displayStringRId(),
+      values = listOf(R.string.bg_model_sliding_window, R.string.bg_model_spring, R.string.bg_model_naive_experimental),
+      displayName = { stringResource(it) },
+      onSelected = { modelResId ->
+        val newModel =
+          when (modelResId) {
+            R.string.bg_model_naive_experimental ->
+              ProtoBrushFamily.InputModel.newBuilder()
+                .setExperimentalNaiveModel(
+                  ProtoBrushFamily.ExperimentalNaiveModel.getDefaultInstance()
+                )
+                .build()
+            R.string.bg_model_sliding_window ->
+              ProtoBrushFamily.InputModel.newBuilder()
+                .setSlidingWindowModel(
+                  ProtoBrushFamily.SlidingWindowModel.newBuilder()
+                    .setWindowSizeSeconds(0.02f)
+                    .setExperimentalUpsamplingPeriodSeconds(0.005f)
+                )
+                .build()
+            R.string.bg_model_spring ->
+              ProtoBrushFamily.InputModel.newBuilder()
+                .setSpringModel(ProtoBrushFamily.SpringModel.getDefaultInstance())
+                .build()
+            else ->
+              ProtoBrushFamily.InputModel.newBuilder()
+                .setSpringModel(ProtoBrushFamily.SpringModel.getDefaultInstance())
+                .build()
+          }
+        onUpdate(data.copy(inputModel = newModel))
+        onDropdownEditComplete()
+      }
+    )
+  }
+  
+  val inputModel = data.inputModel
+  if (inputModel.hasSlidingWindowModel() || (!inputModel.hasSpringModel() && !inputModel.hasExperimentalNaiveModel())) {
+    val swModel = inputModel.slidingWindowModel
+    val windowMs = if (swModel.hasWindowSizeSeconds()) (swModel.windowSizeSeconds * 1000).toLong() else 20L
+    val upsamplingHz = if (swModel.hasExperimentalUpsamplingPeriodSeconds()) {
+        val period = swModel.experimentalUpsamplingPeriodSeconds
+        if (period == Float.POSITIVE_INFINITY || period == 0f) 0 else (1f / period).toInt()
+    } else 180
+
+    Spacer(Modifier.height(16.dp))
+    
+    NumericField(
+      title = stringResource(R.string.brush_designer_window_size_ms),
+      value = windowMs.toFloat(),
+      limits = NumericLimits.standard(1f, 100f, 1f),
+      onValueChanged = { newValue ->
+        val newModel = inputModel.toBuilder()
+          .setSlidingWindowModel(
+            swModel.toBuilder()
+              .setWindowSizeSeconds(newValue / 1000f)
+          )
+          .build()
+        onUpdate(data.copy(inputModel = newModel))
+      }
+    )
+    
+    NumericField(
+      title = stringResource(R.string.brush_designer_upsampling_frequency_hz),
+      value = upsamplingHz.toFloat(),
+      limits = NumericLimits.standard(0f, 500f, 1f),
+      onValueChanged = { newValue ->
+        val newPeriod = if (newValue == 0f) Float.POSITIVE_INFINITY else 1f / newValue
+        val newModel = inputModel.toBuilder()
+          .setSlidingWindowModel(
+            swModel.toBuilder()
+              .setExperimentalUpsamplingPeriodSeconds(newPeriod)
+          )
+          .build()
+        onUpdate(data.copy(inputModel = newModel))
+      }
+    )
+  }
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
@@ -118,7 +118,7 @@ fun FamilyNodeFields(
     NumericField(
       title = stringResource(R.string.brush_designer_window_size_ms),
       value = windowMs.toFloat(),
-      limits = NumericLimits.standard(1f, 100f, 1f),
+      limits = NumericLimits(1f, 100f, 1f),
       onValueChanged = { newValue ->
         val newModel = inputModel.toBuilder()
           .setSlidingWindowModel(
@@ -133,7 +133,7 @@ fun FamilyNodeFields(
     NumericField(
       title = stringResource(R.string.brush_designer_upsampling_frequency_hz),
       value = upsamplingHz.toFloat(),
-      limits = NumericLimits.standard(0f, 500f, 1f),
+      limits = NumericLimits(0f, 500f, 1f),
       onValueChanged = { newValue ->
         val newPeriod = if (newValue == 0f) Float.POSITIVE_INFINITY else 1f / newValue
         val newModel = inputModel.toBuilder()

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.cahier.R
@@ -46,7 +45,6 @@ fun FamilyNodeFields(
   textFieldsLocked: Boolean,
   modifier: Modifier = Modifier
 ) {
-  val context = LocalContext.current
   
   OutlinedTextField(
     value = data.clientBrushFamilyId,

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/FamilyNodeFields.kt
@@ -17,6 +17,7 @@
 
 package com.example.cahier.developer.brushgraph.ui.fields
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -46,104 +47,106 @@ fun FamilyNodeFields(
   modifier: Modifier = Modifier
 ) {
   
-  OutlinedTextField(
-    value = data.clientBrushFamilyId,
-    onValueChange = { onUpdate(data.copy(clientBrushFamilyId = it)) },
-    label = { Text(stringResource(R.string.bg_client_brush_family_id)) },
-    modifier = modifier.fillMaxWidth().padding(vertical = 4.dp),
-    singleLine = true,
-    enabled = !textFieldsLocked,
-  )
-  OutlinedTextField(
-    value = data.developerComment,
-    onValueChange = { onUpdate(data.copy(developerComment = it)) },
-    label = { Text(stringResource(R.string.bg_brush_developer_comment)) },
-    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-    minLines = 3,
-    enabled = !textFieldsLocked,
-  )
-  
-  FieldWithTooltip(
-    tooltipTitle = stringResource(R.string.bg_title_input_model_format, stringResource(data.inputModel.displayStringRId())),
-    tooltipText = stringResource(getInputModelTooltip(data.inputModel.displayStringRId()))
-  ) {
-    EnumDropdown(
-      label = stringResource(R.string.bg_input_model),
-      currentValue = data.inputModel.displayStringRId(),
-      values = listOf(R.string.bg_model_sliding_window, R.string.bg_model_passthrough),
-      displayName = { stringResource(it) },
-      onSelected = { modelResId ->
-        val newModel =
-          when (modelResId) {
-            R.string.bg_model_passthrough ->
-              ProtoBrushFamily.InputModel.newBuilder()
-                .setPassthroughModel(
-                  ProtoBrushFamily.PassthroughModel.getDefaultInstance()
-                )
-                .build()
-            R.string.bg_model_sliding_window ->
-              ProtoBrushFamily.InputModel.newBuilder()
-                .setSlidingWindowModel(
-                  ProtoBrushFamily.SlidingWindowModel.newBuilder()
-                    .setWindowSizeSeconds(0.02f)
-                    .setExperimentalUpsamplingPeriodSeconds(0.005f)
-                )
-                .build()
-            else ->
-              ProtoBrushFamily.InputModel.newBuilder()
-                .setSlidingWindowModel(
-                  ProtoBrushFamily.SlidingWindowModel.newBuilder()
-                    .setWindowSizeSeconds(0.02f)
-                    .setExperimentalUpsamplingPeriodSeconds(0.005f)
-                )
-                .build()
-          }
-        onUpdate(data.copy(inputModel = newModel))
-        onDropdownEditComplete()
-      }
+  Column(modifier = modifier) {
+    OutlinedTextField(
+      value = data.clientBrushFamilyId,
+      onValueChange = { onUpdate(data.copy(clientBrushFamilyId = it)) },
+      label = { Text(stringResource(R.string.bg_client_brush_family_id)) },
+      modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+      singleLine = true,
+      enabled = !textFieldsLocked,
     )
-  }
-  
-  val inputModel = data.inputModel
-  if (inputModel.hasSlidingWindowModel() || !inputModel.hasPassthroughModel()) {
-    val swModel = inputModel.slidingWindowModel
-    val windowMs = if (swModel.hasWindowSizeSeconds()) (swModel.windowSizeSeconds * 1000).toLong() else 20L
-    val upsamplingHz = if (swModel.hasExperimentalUpsamplingPeriodSeconds()) {
-        val period = swModel.experimentalUpsamplingPeriodSeconds
-        if (period == Float.POSITIVE_INFINITY || period == 0f) 0 else (1f / period).toInt()
-    } else 180
+    OutlinedTextField(
+      value = data.developerComment,
+      onValueChange = { onUpdate(data.copy(developerComment = it)) },
+      label = { Text(stringResource(R.string.bg_brush_developer_comment)) },
+      modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+      minLines = 3,
+      enabled = !textFieldsLocked,
+    )
+    
+    FieldWithTooltip(
+      tooltipTitle = stringResource(R.string.bg_title_input_model_format, stringResource(data.inputModel.displayStringRId())),
+      tooltipText = stringResource(getInputModelTooltip(data.inputModel.displayStringRId()))
+    ) {
+      EnumDropdown(
+        label = stringResource(R.string.bg_input_model),
+        currentValue = data.inputModel.displayStringRId(),
+        values = listOf(R.string.bg_model_sliding_window, R.string.bg_model_passthrough),
+        displayName = { stringResource(it) },
+        onSelected = { modelResId ->
+          val newModel =
+            when (modelResId) {
+              R.string.bg_model_passthrough ->
+                ProtoBrushFamily.InputModel.newBuilder()
+                  .setPassthroughModel(
+                    ProtoBrushFamily.PassthroughModel.getDefaultInstance()
+                  )
+                  .build()
+              R.string.bg_model_sliding_window ->
+                ProtoBrushFamily.InputModel.newBuilder()
+                  .setSlidingWindowModel(
+                    ProtoBrushFamily.SlidingWindowModel.newBuilder()
+                      .setWindowSizeSeconds(0.02f)
+                      .setExperimentalUpsamplingPeriodSeconds(0.005f)
+                  )
+                  .build()
+              else ->
+                ProtoBrushFamily.InputModel.newBuilder()
+                  .setSlidingWindowModel(
+                    ProtoBrushFamily.SlidingWindowModel.newBuilder()
+                      .setWindowSizeSeconds(0.02f)
+                      .setExperimentalUpsamplingPeriodSeconds(0.005f)
+                  )
+                  .build()
+            }
+          onUpdate(data.copy(inputModel = newModel))
+          onDropdownEditComplete()
+        }
+      )
+    }
+    
+    val inputModel = data.inputModel
+    if (inputModel.hasSlidingWindowModel() || !inputModel.hasPassthroughModel()) {
+      val swModel = inputModel.slidingWindowModel
+      val windowMs = if (swModel.hasWindowSizeSeconds()) (swModel.windowSizeSeconds * 1000).toLong() else 20L
+      val upsamplingHz = if (swModel.hasExperimentalUpsamplingPeriodSeconds()) {
+          val period = swModel.experimentalUpsamplingPeriodSeconds
+          if (period == Float.POSITIVE_INFINITY || period == 0f) 0 else (1f / period).toInt()
+      } else 180
 
-    Spacer(Modifier.height(16.dp))
-    
-    NumericField(
-      title = stringResource(R.string.brush_designer_window_size_ms),
-      value = windowMs.toFloat(),
-      limits = NumericLimits(1f, 100f, 1f),
-      onValueChanged = { newValue ->
-        val newModel = inputModel.toBuilder()
-          .setSlidingWindowModel(
-            swModel.toBuilder()
-              .setWindowSizeSeconds(newValue / 1000f)
-          )
-          .build()
-        onUpdate(data.copy(inputModel = newModel))
-      }
-    )
-    
-    NumericField(
-      title = stringResource(R.string.brush_designer_upsampling_frequency_hz),
-      value = upsamplingHz.toFloat(),
-      limits = NumericLimits(0f, 500f, 1f),
-      onValueChanged = { newValue ->
-        val newPeriod = if (newValue == 0f) Float.POSITIVE_INFINITY else 1f / newValue
-        val newModel = inputModel.toBuilder()
-          .setSlidingWindowModel(
-            swModel.toBuilder()
-              .setExperimentalUpsamplingPeriodSeconds(newPeriod)
-          )
-          .build()
-        onUpdate(data.copy(inputModel = newModel))
-      }
-    )
+      Spacer(Modifier.height(16.dp))
+      
+      NumericField(
+        title = stringResource(R.string.brush_designer_window_size_ms),
+        value = windowMs.toFloat(),
+        limits = NumericLimits(1f, 100f, 1f),
+        onValueChanged = { newValue ->
+          val newModel = inputModel.toBuilder()
+            .setSlidingWindowModel(
+              swModel.toBuilder()
+                .setWindowSizeSeconds(newValue / 1000f)
+            )
+            .build()
+          onUpdate(data.copy(inputModel = newModel))
+        }
+      )
+      
+      NumericField(
+        title = stringResource(R.string.brush_designer_upsampling_frequency_hz),
+        value = upsamplingHz.toFloat(),
+        limits = NumericLimits(0f, 500f, 1f),
+        onValueChanged = { newValue ->
+          val newPeriod = if (newValue == 0f) Float.POSITIVE_INFINITY else 1f / newValue
+          val newModel = inputModel.toBuilder()
+            .setSlidingWindowModel(
+              swModel.toBuilder()
+                .setExperimentalUpsamplingPeriodSeconds(newPeriod)
+            )
+            .build()
+          onUpdate(data.copy(inputModel = newModel))
+        }
+      )
+    }
   }
 }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NodeFields.kt
@@ -75,18 +75,19 @@ import com.example.cahier.developer.brushgraph.ui.TipPreviewWidget
 @Composable
 fun NodeFields(
   node: GraphNode,
+  textFieldsLocked: Boolean,
+  strokeRenderer: CanvasStrokeRenderer,
+  allTextureIds: Set<String>,
   onChooseColor: (Color, (Color) -> Unit) -> Unit,
   onUpdate: (NodeData) -> Unit,
-  textFieldsLocked: Boolean,
-  allTextureIds: Set<String>,
   onLoadTexture: () -> Unit,
-  strokeRenderer: CanvasStrokeRenderer,
   onFieldEditComplete: () -> Unit = {},
   onDropdownEditComplete: () -> Unit = {},
+  modifier: Modifier = Modifier,
 ) {
   Column(
     modifier =
-      Modifier.padding(top = 8.dp).heightIn(max = 600.dp).verticalScroll(rememberScrollState())
+      modifier.padding(top = 8.dp).heightIn(max = 600.dp).verticalScroll(rememberScrollState())
   ) {
     when (val data = node.data) {
       is NodeData.Behavior -> {

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NodeFields.kt
@@ -1,0 +1,264 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(
+  androidx.ink.brush.ExperimentalInkCustomBrushApi::class,
+  androidx.compose.material3.ExperimentalMaterial3Api::class
+)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Help
+import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.cahier.R
+import ink.proto.BrushBehavior as ProtoBrushBehavior
+import ink.proto.BrushCoat as ProtoBrushCoat
+import ink.proto.BrushFamily as ProtoBrushFamily
+import ink.proto.BrushPaint as ProtoBrushPaint
+import ink.proto.BrushTip as ProtoBrushTip
+import ink.proto.ColorFunction as ProtoColorFunction
+import ink.proto.PredefinedEasingFunction as ProtoPredefinedEasingFunction
+import androidx.ink.brush.InputToolType
+import androidx.ink.rendering.android.canvas.CanvasStrokeRenderer
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.layout.fillMaxWidth
+
+import com.example.cahier.developer.brushgraph.data.*
+import com.example.cahier.developer.brushgraph.ui.TipPreviewWidget
+
+/** Renders the editable fields for a node. */
+@Composable
+fun NodeFields(
+  node: GraphNode,
+  onChooseColor: (Color, (Color) -> Unit) -> Unit,
+  onUpdate: (NodeData) -> Unit,
+  textFieldsLocked: Boolean,
+  allTextureIds: Set<String>,
+  onLoadTexture: () -> Unit,
+  strokeRenderer: CanvasStrokeRenderer,
+  onFieldEditComplete: () -> Unit = {},
+  onDropdownEditComplete: () -> Unit = {},
+) {
+  Column(
+    modifier =
+      Modifier.padding(top = 8.dp).heightIn(max = 600.dp).verticalScroll(rememberScrollState())
+  ) {
+    when (val data = node.data) {
+      is NodeData.Behavior -> {
+        BehaviorNodeFields(
+          data = data,
+          onUpdate = onUpdate,
+          onDropdownEditComplete = onDropdownEditComplete,
+          onFieldEditComplete = onFieldEditComplete,
+          textFieldsLocked = textFieldsLocked
+        )
+      }
+      is NodeData.ColorFunction -> {
+        ColorFunctionNodeFields(
+          function = data.function,
+          onUpdate = onUpdate,
+          onChooseColor = onChooseColor,
+          onDropdownEditComplete = onDropdownEditComplete,
+          onFieldEditComplete = onFieldEditComplete
+        )
+      }
+      is NodeData.Family -> {
+        FamilyNodeFields(
+          data = data,
+          onUpdate = onUpdate,
+          onDropdownEditComplete = onDropdownEditComplete,
+          textFieldsLocked = textFieldsLocked
+        )
+      }
+      is NodeData.Tip -> {
+        TipNodeFields(
+          data = data,
+          onUpdate = onUpdate,
+          onFieldEditComplete = onFieldEditComplete,
+          strokeRenderer = strokeRenderer
+        )
+      }
+      is NodeData.Coat -> {
+        CoatNodeFields()
+      }
+      is NodeData.Paint -> {
+        PaintNodeFields(
+          data = data,
+          onUpdate = onUpdate,
+          onDropdownEditComplete = onDropdownEditComplete
+        )
+      }
+      is NodeData.TextureLayer -> {
+        TextureLayerNodeFields(
+          layer = data.layer,
+          allTextureIds = allTextureIds,
+          onLoadTexture = onLoadTexture,
+          onUpdate = { onUpdate(it) },
+          strokeRenderer = strokeRenderer
+        )
+      }
+    }
+  }
+}
+
+internal fun createDefaultNode(nodeCase: ProtoBrushBehavior.Node.NodeCase): NodeData {
+  return when (nodeCase) {
+    ProtoBrushBehavior.Node.NodeCase.SOURCE_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setSourceNode(
+            ProtoBrushBehavior.SourceNode.newBuilder()
+              .setSource(ProtoBrushBehavior.Source.SOURCE_NORMALIZED_PRESSURE)
+              .setSourceValueRangeStart(0f)
+              .setSourceValueRangeEnd(1f)
+              .setSourceOutOfRangeBehavior(ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP)
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.CONSTANT_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setConstantNode(ProtoBrushBehavior.ConstantNode.newBuilder().setValue(0f))
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.NOISE_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setNoiseNode(
+            ProtoBrushBehavior.NoiseNode.newBuilder()
+              .setSeed(0)
+              .setVaryOver(ProtoBrushBehavior.ProgressDomain.PROGRESS_DOMAIN_DISTANCE_IN_MULTIPLES_OF_BRUSH_SIZE)
+              .setBasePeriod(1f)
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.TOOL_TYPE_FILTER_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setToolTypeFilterNode(
+            ProtoBrushBehavior.ToolTypeFilterNode.newBuilder()
+              .setEnabledToolTypes(1 shl 3) // Stylus
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.DAMPING_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setDampingNode(
+            ProtoBrushBehavior.DampingNode.newBuilder()
+              .setDampingSource(ProtoBrushBehavior.ProgressDomain.PROGRESS_DOMAIN_DISTANCE_IN_MULTIPLES_OF_BRUSH_SIZE)
+              .setDampingGap(0.1f)
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.RESPONSE_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setResponseNode(
+            ProtoBrushBehavior.ResponseNode.newBuilder()
+              .setPredefinedResponseCurve(ProtoPredefinedEasingFunction.PREDEFINED_EASING_LINEAR)
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.INTEGRAL_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setIntegralNode(
+            ProtoBrushBehavior.IntegralNode.newBuilder()
+              .setIntegrateOver(ProtoBrushBehavior.ProgressDomain.PROGRESS_DOMAIN_DISTANCE_IN_CENTIMETERS)
+              .setIntegralValueRangeStart(0f)
+              .setIntegralValueRangeEnd(1f)
+              .setIntegralOutOfRangeBehavior(ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP)
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.BINARY_OP_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setBinaryOpNode(
+            ProtoBrushBehavior.BinaryOpNode.newBuilder()
+              .setOperation(ProtoBrushBehavior.BinaryOp.BINARY_OP_SUM)
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.INTERPOLATION_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setInterpolationNode(
+            ProtoBrushBehavior.InterpolationNode.newBuilder()
+              .setInterpolation(ProtoBrushBehavior.Interpolation.INTERPOLATION_LERP)
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.TARGET_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setTargetNode(
+            ProtoBrushBehavior.TargetNode.newBuilder()
+              .setTarget(ProtoBrushBehavior.Target.TARGET_WIDTH_MULTIPLIER)
+              .setTargetModifierRangeStart(0f)
+              .setTargetModifierRangeEnd(1f)
+          )
+          .build()
+      )
+    ProtoBrushBehavior.Node.NodeCase.POLAR_TARGET_NODE ->
+      NodeData.Behavior(
+        ProtoBrushBehavior.Node.newBuilder()
+          .setPolarTargetNode(
+            ProtoBrushBehavior.PolarTargetNode.newBuilder()
+              .setTarget(ProtoBrushBehavior.PolarTarget.POLAR_POSITION_OFFSET_RELATIVE_IN_RADIANS_AND_MULTIPLES_OF_BRUSH_SIZE)
+              .setAngleRangeStart(0f)
+              .setAngleRangeEnd(6.28f)
+              .setMagnitudeRangeStart(0f)
+              .setMagnitudeRangeEnd(1f)
+          )
+          .build()
+      )
+    else -> throw IllegalArgumentException("Unsupported node case: $nodeCase")
+  }
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NoiseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NoiseNodeFields.kt
@@ -1,0 +1,111 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.cahier.R
+import com.example.cahier.developer.brushdesigner.ui.EnumDropdown
+import com.example.cahier.developer.brushdesigner.ui.NumericField
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.ProgressDomainContext
+import com.example.cahier.developer.brushgraph.data.getNumericLimits
+import com.example.cahier.developer.brushgraph.ui.getTooltip
+import com.example.cahier.developer.brushgraph.ui.FieldWithTooltip
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import ink.proto.BrushBehavior as ProtoBrushBehavior
+
+@Composable
+fun NoiseNodeFields(
+  noiseNode: ProtoBrushBehavior.NoiseNode,
+  behaviorNode: ProtoBrushBehavior.Node,
+  onUpdate: (NodeData) -> Unit,
+  onFieldEditComplete: () -> Unit,
+  onDropdownEditComplete: () -> Unit,
+  textFieldsLocked: Boolean,
+  modifier: Modifier = Modifier
+) {
+  val limits = noiseNode.varyOver.getNumericLimits(ProgressDomainContext.NOISE)
+  
+  NumericField(
+    title = stringResource(R.string.bg_label_seed),
+    value = noiseNode.seed.toFloat(),
+    limits = NumericLimits.standard(0f, 100f, 1f),
+    onValueChanged = {
+      onUpdate(
+        NodeData.Behavior(
+          behaviorNode.toBuilder()
+            .setNoiseNode(noiseNode.toBuilder().setSeed(it.toInt()).build())
+            .build()
+        )
+      )
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+  
+  FieldWithTooltip(
+    tooltipTitle = stringResource(R.string.bg_title_vary_over_format, stringResource(noiseNode.varyOver.displayStringRId())),
+    tooltipText = stringResource(noiseNode.varyOver.getTooltip())
+  ) {
+    EnumDropdown(
+      label = stringResource(R.string.bg_vary_over),
+      currentValue = noiseNode.varyOver,
+      values = ALL_PROGRESS_DOMAINS.toList(),
+      displayName = { stringResource(it.displayStringRId()) },
+      onSelected = { domain ->
+        val newLimits = domain.getNumericLimits(ProgressDomainContext.NOISE)
+        val clampedBasePeriod = noiseNode.basePeriod.coerceIn(newLimits.min, newLimits.max)
+
+        onUpdate(
+          NodeData.Behavior(
+            behaviorNode.toBuilder()
+              .setNoiseNode(
+                noiseNode.toBuilder()
+                  .setVaryOver(domain)
+                  .setBasePeriod(clampedBasePeriod)
+                  .build()
+              )
+              .build()
+          )
+        )
+        onDropdownEditComplete()
+      }
+    )
+  }
+  
+  NumericField(
+    title = stringResource(R.string.bg_label_base_period),
+    value = noiseNode.basePeriod,
+    limits = limits,
+    onValueChanged = {
+      onUpdate(
+        NodeData.Behavior(
+          behaviorNode.toBuilder()
+            .setNoiseNode(noiseNode.toBuilder().setBasePeriod(it).build())
+            .build()
+        )
+      )
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NoiseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NoiseNodeFields.kt
@@ -17,6 +17,7 @@
 
 package com.example.cahier.developer.brushgraph.ui.fields
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -47,66 +48,67 @@ fun NoiseNodeFields(
 ) {
   val limits = noiseNode.varyOver.getNumericLimits(ProgressDomainContext.NOISE)
   
-  NumericField(
-    modifier = modifier,
-    title = stringResource(R.string.bg_label_seed),
-    value = noiseNode.seed.toFloat(),
-    limits = NumericLimits(0f, 100f, 1f),
-    onValueChanged = {
-      onUpdate(
-        NodeData.Behavior(
-          behaviorNode.toBuilder()
-            .setNoiseNode(noiseNode.toBuilder().setSeed(it.toInt()).build())
-            .build()
-        )
-      )
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
-  
-  FieldWithTooltip(
-    tooltipTitle = stringResource(R.string.bg_title_vary_over_format, stringResource(noiseNode.varyOver.displayStringRId())),
-    tooltipText = stringResource(noiseNode.varyOver.getTooltip())
-  ) {
-    EnumDropdown(
-      label = stringResource(R.string.bg_vary_over),
-      currentValue = noiseNode.varyOver,
-      values = ALL_PROGRESS_DOMAINS.toList(),
-      displayName = { stringResource(it.displayStringRId()) },
-      onSelected = { domain ->
-        val newLimits = domain.getNumericLimits(ProgressDomainContext.NOISE)
-        val clampedBasePeriod = noiseNode.basePeriod.coerceIn(newLimits.min, newLimits.max)
-
+  Column(modifier = modifier) {
+    NumericField(
+      title = stringResource(R.string.bg_label_seed),
+      value = noiseNode.seed.toFloat(),
+      limits = NumericLimits(0f, 100f, 1f),
+      onValueChanged = {
         onUpdate(
           NodeData.Behavior(
             behaviorNode.toBuilder()
-              .setNoiseNode(
-                noiseNode.toBuilder()
-                  .setVaryOver(domain)
-                  .setBasePeriod(clampedBasePeriod)
-                  .build()
-              )
+              .setNoiseNode(noiseNode.toBuilder().setSeed(it.toInt()).build())
               .build()
           )
         )
-        onDropdownEditComplete()
-      }
+      },
+      onValueChangeFinished = onFieldEditComplete
+    )
+    
+    FieldWithTooltip(
+      tooltipTitle = stringResource(R.string.bg_title_vary_over_format, stringResource(noiseNode.varyOver.displayStringRId())),
+      tooltipText = stringResource(noiseNode.varyOver.getTooltip())
+    ) {
+      EnumDropdown(
+        label = stringResource(R.string.bg_vary_over),
+        currentValue = noiseNode.varyOver,
+        values = ALL_PROGRESS_DOMAINS.toList(),
+        displayName = { stringResource(it.displayStringRId()) },
+        onSelected = { domain ->
+          val newLimits = domain.getNumericLimits(ProgressDomainContext.NOISE)
+          val clampedBasePeriod = noiseNode.basePeriod.coerceIn(newLimits.min, newLimits.max)
+
+          onUpdate(
+            NodeData.Behavior(
+              behaviorNode.toBuilder()
+                .setNoiseNode(
+                  noiseNode.toBuilder()
+                    .setVaryOver(domain)
+                    .setBasePeriod(clampedBasePeriod)
+                    .build()
+                )
+                .build()
+            )
+          )
+          onDropdownEditComplete()
+        }
+      )
+    }
+    
+    NumericField(
+      title = stringResource(R.string.bg_label_base_period),
+      value = noiseNode.basePeriod,
+      limits = limits,
+      onValueChanged = {
+        onUpdate(
+          NodeData.Behavior(
+            behaviorNode.toBuilder()
+              .setNoiseNode(noiseNode.toBuilder().setBasePeriod(it).build())
+              .build()
+          )
+        )
+      },
+      onValueChangeFinished = onFieldEditComplete
     )
   }
-  
-  NumericField(
-    title = stringResource(R.string.bg_label_base_period),
-    value = noiseNode.basePeriod,
-    limits = limits,
-    onValueChanged = {
-      onUpdate(
-        NodeData.Behavior(
-          behaviorNode.toBuilder()
-            .setNoiseNode(noiseNode.toBuilder().setBasePeriod(it).build())
-            .build()
-        )
-      )
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
 }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NoiseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NoiseNodeFields.kt
@@ -50,7 +50,7 @@ fun NoiseNodeFields(
   NumericField(
     title = stringResource(R.string.bg_label_seed),
     value = noiseNode.seed.toFloat(),
-    limits = NumericLimits.standard(0f, 100f, 1f),
+    limits = NumericLimits(0f, 100f, 1f),
     onValueChanged = {
       onUpdate(
         NodeData.Behavior(

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NoiseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/NoiseNodeFields.kt
@@ -48,6 +48,7 @@ fun NoiseNodeFields(
   val limits = noiseNode.varyOver.getNumericLimits(ProgressDomainContext.NOISE)
   
   NumericField(
+    modifier = modifier,
     title = stringResource(R.string.bg_label_seed),
     value = noiseNode.seed.toFloat(),
     limits = NumericLimits(0f, 100f, 1f),

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/PolarTargetNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/PolarTargetNodeFields.kt
@@ -1,0 +1,119 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.example.cahier.R
+import com.example.cahier.developer.brushdesigner.ui.EnumDropdown
+import com.example.cahier.developer.brushdesigner.ui.NumericField
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.getNumericLimits
+import com.example.cahier.developer.brushgraph.ui.getTooltip
+import com.example.cahier.developer.brushgraph.ui.FieldWithTooltip
+import com.example.cahier.developer.brushgraph.ui.fields.ALL_POLAR_TARGETS
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import ink.proto.BrushBehavior as ProtoBrushBehavior
+
+@Composable
+fun PolarTargetNodeFields(
+  polarNode: ProtoBrushBehavior.PolarTargetNode,
+  behaviorNode: ProtoBrushBehavior.Node,
+  onUpdate: (NodeData) -> Unit,
+  onFieldEditComplete: () -> Unit,
+  onDropdownEditComplete: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  FieldWithTooltip(
+    tooltipTitle = stringResource(R.string.bg_title_polar_target_format, stringResource(polarNode.target.displayStringRId())),
+    tooltipText = stringResource(polarNode.target.getTooltip()),
+    modifier = modifier
+  ) {
+    EnumDropdown(
+      label = stringResource(R.string.bg_polar_target),
+      currentValue = polarNode.target,
+      values = ALL_POLAR_TARGETS.toList(),
+      displayName = { stringResource(it.displayStringRId()) },
+      onSelected = { target ->
+        val newMagLimits = NumericLimits.standard(-10.0f, 10.0f, 0.01f)
+        val clampedMagStart = polarNode.magnitudeRangeStart.coerceIn(newMagLimits.min, newMagLimits.max)
+        val clampedMagEnd = polarNode.magnitudeRangeEnd.coerceIn(newMagLimits.min, newMagLimits.max)
+
+        onUpdate(
+          NodeData.Behavior(
+            behaviorNode.toBuilder()
+              .setPolarTargetNode(
+                polarNode.toBuilder()
+                  .setTarget(target)
+                  .setMagnitudeRangeStart(clampedMagStart)
+                  .setMagnitudeRangeEnd(clampedMagEnd)
+                  .build()
+              )
+              .build()
+          )
+        )
+        onDropdownEditComplete()
+      }
+    )
+  }
+  
+  NumericField(
+    title = stringResource(R.string.bg_label_angle_start),
+    value = polarNode.angleRangeStart,
+    limits = NumericLimits.radiansShownAsDegrees(-360f, 360f),
+    onValueChanged = {
+      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setAngleRangeStart(it).build()).build()))
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+  
+  NumericField(
+    title = stringResource(R.string.bg_label_angle_end),
+    value = polarNode.angleRangeEnd,
+    limits = NumericLimits.radiansShownAsDegrees(-360f, 360f),
+    onValueChanged = {
+      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setAngleRangeEnd(it).build()).build()))
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+  
+  val magLimits = NumericLimits.standard(-10.0f, 10.0f, 0.01f)
+  
+  NumericField(
+    title = stringResource(R.string.bg_label_mag_start),
+    value = polarNode.magnitudeRangeStart,
+    limits = magLimits,
+    onValueChanged = {
+      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setMagnitudeRangeStart(it).build()).build()))
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+  
+  NumericField(
+    title = stringResource(R.string.bg_label_mag_end),
+    value = polarNode.magnitudeRangeEnd,
+    limits = magLimits,
+    onValueChanged = {
+      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setMagnitudeRangeEnd(it).build()).build()))
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/PolarTargetNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/PolarTargetNodeFields.kt
@@ -17,6 +17,7 @@
 
 package com.example.cahier.developer.brushgraph.ui.fields
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -42,78 +43,79 @@ fun PolarTargetNodeFields(
   onDropdownEditComplete: () -> Unit,
   modifier: Modifier = Modifier
 ) {
-  FieldWithTooltip(
-    tooltipTitle = stringResource(R.string.bg_title_polar_target_format, stringResource(polarNode.target.displayStringRId())),
-    tooltipText = stringResource(polarNode.target.getTooltip()),
-    modifier = modifier
-  ) {
-    EnumDropdown(
-      label = stringResource(R.string.bg_polar_target),
-      currentValue = polarNode.target,
-      values = ALL_POLAR_TARGETS.toList(),
-      displayName = { stringResource(it.displayStringRId()) },
-      onSelected = { target ->
-        val newMagLimits = NumericLimits(-10.0f, 10.0f, 0.01f)
-        val clampedMagStart = polarNode.magnitudeRangeStart.coerceIn(newMagLimits.min, newMagLimits.max)
-        val clampedMagEnd = polarNode.magnitudeRangeEnd.coerceIn(newMagLimits.min, newMagLimits.max)
+  Column(modifier = modifier) {
+    FieldWithTooltip(
+      tooltipTitle = stringResource(R.string.bg_title_polar_target_format, stringResource(polarNode.target.displayStringRId())),
+      tooltipText = stringResource(polarNode.target.getTooltip()),
+    ) {
+      EnumDropdown(
+        label = stringResource(R.string.bg_polar_target),
+        currentValue = polarNode.target,
+        values = ALL_POLAR_TARGETS.toList(),
+        displayName = { stringResource(it.displayStringRId()) },
+        onSelected = { target ->
+          val newMagLimits = NumericLimits(-10.0f, 10.0f, 0.01f)
+          val clampedMagStart = polarNode.magnitudeRangeStart.coerceIn(newMagLimits.min, newMagLimits.max)
+          val clampedMagEnd = polarNode.magnitudeRangeEnd.coerceIn(newMagLimits.min, newMagLimits.max)
 
-        onUpdate(
-          NodeData.Behavior(
-            behaviorNode.toBuilder()
-              .setPolarTargetNode(
-                polarNode.toBuilder()
-                  .setTarget(target)
-                  .setMagnitudeRangeStart(clampedMagStart)
-                  .setMagnitudeRangeEnd(clampedMagEnd)
-                  .build()
-              )
-              .build()
+          onUpdate(
+            NodeData.Behavior(
+              behaviorNode.toBuilder()
+                .setPolarTargetNode(
+                  polarNode.toBuilder()
+                    .setTarget(target)
+                    .setMagnitudeRangeStart(clampedMagStart)
+                    .setMagnitudeRangeEnd(clampedMagEnd)
+                    .build()
+                )
+                .build()
+            )
           )
-        )
-        onDropdownEditComplete()
-      }
+          onDropdownEditComplete()
+        }
+      )
+    }
+    
+    NumericField(
+      title = stringResource(R.string.bg_label_angle_start),
+      value = polarNode.angleRangeStart,
+      limits = NumericLimits.radiansShownAsDegrees(-360f, 360f),
+      onValueChanged = {
+        onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setAngleRangeStart(it).build()).build()))
+      },
+      onValueChangeFinished = onFieldEditComplete
+    )
+    
+    NumericField(
+      title = stringResource(R.string.bg_label_angle_end),
+      value = polarNode.angleRangeEnd,
+      limits = NumericLimits.radiansShownAsDegrees(-360f, 360f),
+      onValueChanged = {
+        onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setAngleRangeEnd(it).build()).build()))
+      },
+      onValueChangeFinished = onFieldEditComplete
+    )
+    
+    val magLimits = NumericLimits(-10.0f, 10.0f, 0.01f)
+    
+    NumericField(
+      title = stringResource(R.string.bg_label_mag_start),
+      value = polarNode.magnitudeRangeStart,
+      limits = magLimits,
+      onValueChanged = {
+        onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setMagnitudeRangeStart(it).build()).build()))
+      },
+      onValueChangeFinished = onFieldEditComplete
+    )
+    
+    NumericField(
+      title = stringResource(R.string.bg_label_mag_end),
+      value = polarNode.magnitudeRangeEnd,
+      limits = magLimits,
+      onValueChanged = {
+        onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setMagnitudeRangeEnd(it).build()).build()))
+      },
+      onValueChangeFinished = onFieldEditComplete
     )
   }
-  
-  NumericField(
-    title = stringResource(R.string.bg_label_angle_start),
-    value = polarNode.angleRangeStart,
-    limits = NumericLimits.radiansShownAsDegrees(-360f, 360f),
-    onValueChanged = {
-      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setAngleRangeStart(it).build()).build()))
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
-  
-  NumericField(
-    title = stringResource(R.string.bg_label_angle_end),
-    value = polarNode.angleRangeEnd,
-    limits = NumericLimits.radiansShownAsDegrees(-360f, 360f),
-    onValueChanged = {
-      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setAngleRangeEnd(it).build()).build()))
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
-  
-  val magLimits = NumericLimits(-10.0f, 10.0f, 0.01f)
-  
-  NumericField(
-    title = stringResource(R.string.bg_label_mag_start),
-    value = polarNode.magnitudeRangeStart,
-    limits = magLimits,
-    onValueChanged = {
-      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setMagnitudeRangeStart(it).build()).build()))
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
-  
-  NumericField(
-    title = stringResource(R.string.bg_label_mag_end),
-    value = polarNode.magnitudeRangeEnd,
-    limits = magLimits,
-    onValueChanged = {
-      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setPolarTargetNode(polarNode.toBuilder().setMagnitudeRangeEnd(it).build()).build()))
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
 }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/PolarTargetNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/PolarTargetNodeFields.kt
@@ -53,7 +53,7 @@ fun PolarTargetNodeFields(
       values = ALL_POLAR_TARGETS.toList(),
       displayName = { stringResource(it.displayStringRId()) },
       onSelected = { target ->
-        val newMagLimits = NumericLimits.standard(-10.0f, 10.0f, 0.01f)
+        val newMagLimits = NumericLimits(-10.0f, 10.0f, 0.01f)
         val clampedMagStart = polarNode.magnitudeRangeStart.coerceIn(newMagLimits.min, newMagLimits.max)
         val clampedMagEnd = polarNode.magnitudeRangeEnd.coerceIn(newMagLimits.min, newMagLimits.max)
 
@@ -95,7 +95,7 @@ fun PolarTargetNodeFields(
     onValueChangeFinished = onFieldEditComplete
   )
   
-  val magLimits = NumericLimits.standard(-10.0f, 10.0f, 0.01f)
+  val magLimits = NumericLimits(-10.0f, 10.0f, 0.01f)
   
   NumericField(
     title = stringResource(R.string.bg_label_mag_start),

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
@@ -277,7 +277,7 @@ fun ResponseCurveWidget(
 
   val selectedTabIndex = tabs.indexOf(currentCase).coerceAtLeast(0)
 
-  Column {
+  Column(modifier = modifier) {
     TabRow(selectedTabIndex = selectedTabIndex) {
       tabs.forEachIndexed { index, case ->
         Tab(
@@ -322,7 +322,7 @@ fun ResponseCurveWidget(
 
     Box(
       modifier =
-        modifier.padding(vertical = 8.dp).border(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        Modifier.padding(vertical = 8.dp).border(1.dp, MaterialTheme.colorScheme.outlineVariant)
     ) {
       when (currentCase) {
         ProtoBrushBehavior.ResponseNode.ResponseCurveCase.CUBIC_BEZIER_RESPONSE_CURVE ->

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
@@ -179,18 +179,43 @@ fun CurvePreviewWidget(
               path.lineTo(widthPx, centerY - scaleY)
             }
             else -> {
-              val (x1, y1, x2, y2) =
-                when (func) {
-                  ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE ->
-                    listOf(0.25f, 0.1f, 0.25f, 1f)
-                  ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_IN ->
-                    listOf(0.42f, 0f, 1f, 1f)
-                  ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_OUT ->
-                    listOf(0f, 0f, 0.58f, 1f)
-                  ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_IN_OUT ->
-                    listOf(0.42f, 0f, 0.58f, 1f)
-                  else -> listOf(0f, 0f, 1f, 1f)
+              var x1 = 0f
+              var y1 = 0f
+              var x2 = 1f
+              var y2 = 1f
+              
+              when (func) {
+                ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE -> {
+                  x1 = 0.25f
+                  y1 = 0.1f
+                  x2 = 0.25f
+                  y2 = 1f
                 }
+                ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_IN -> {
+                  x1 = 0.42f
+                  y1 = 0f
+                  x2 = 1f
+                  y2 = 1f
+                }
+                ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_OUT -> {
+                  x1 = 0f
+                  y1 = 0f
+                  x2 = 0.58f
+                  y2 = 1f
+                }
+                ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_IN_OUT -> {
+                  x1 = 0.42f
+                  y1 = 0f
+                  x2 = 0.58f
+                  y2 = 1f
+                }
+                else -> {
+                  x1 = 0f
+                  y1 = 0f
+                  x2 = 1f
+                  y2 = 1f
+                }
+              }
               path.moveTo(0f, centerY)
               path.cubicTo(
                 x1 * widthPx,

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
@@ -373,7 +373,7 @@ fun LinearWidget(
           NumericField(
             title = "X",
             value = curve.getX(i),
-            limits = NumericLimits.standard(0f, 1f, 0.01f),
+            limits = NumericLimits(0f, 1f, 0.01f),
             onValueChanged = { newValue ->
               val builder = curve.toBuilder()
               builder.setX(i, newValue)
@@ -386,7 +386,7 @@ fun LinearWidget(
           NumericField(
             title = "Y",
             value = curve.getY(i),
-            limits = NumericLimits.standard(-2f, 2f, 0.01f),
+            limits = NumericLimits(-2f, 2f, 0.01f),
             onValueChanged = { newValue ->
               val builder = curve.toBuilder()
               builder.setY(i, newValue)
@@ -420,10 +420,10 @@ fun LinearWidget(
 @Composable
 fun CubicBezierWidget(curve: ProtoCubicBezier, onCurveChanged: (ProtoCubicBezier) -> Unit) {
   Column(modifier = Modifier.padding(8.dp)) {
-    NumericField(title = "x1", value = curve.x1, limits = NumericLimits.standard(0f, 1f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setX1(it).build()) })
-    NumericField(title = "y1", value = curve.y1, limits = NumericLimits.standard(-2f, 2f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setY1(it).build()) })
-    NumericField(title = "x2", value = curve.x2, limits = NumericLimits.standard(0f, 1f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setX2(it).build()) })
-    NumericField(title = "y2", value = curve.y2, limits = NumericLimits.standard(-2f, 2f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setY2(it).build()) })
+    NumericField(title = "x1", value = curve.x1, limits = NumericLimits(0f, 1f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setX1(it).build()) })
+    NumericField(title = "y1", value = curve.y1, limits = NumericLimits(-2f, 2f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setY1(it).build()) })
+    NumericField(title = "x2", value = curve.x2, limits = NumericLimits(0f, 1f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setX2(it).build()) })
+    NumericField(title = "y2", value = curve.y2, limits = NumericLimits(-2f, 2f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setY2(it).build()) })
   }
 }
 
@@ -433,7 +433,7 @@ fun StepsWidget(curve: ProtoSteps, onCurveChanged: (ProtoSteps) -> Unit) {
     NumericField(
       title = stringResource(R.string.bg_label_step_count),
       value = curve.stepCount.toFloat(),
-      limits = NumericLimits.standard(1f, 20f, 1f),
+      limits = NumericLimits(1f, 20f, 1f),
       onValueChanged = {
         onCurveChanged(curve.toBuilder().setStepCount(it.toInt()).build())
       }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
@@ -1,0 +1,447 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.ink.brush.ExperimentalInkCustomBrushApi::class, androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import ink.proto.PredefinedEasingFunction as ProtoPredefinedEasingFunction
+import ink.proto.StepPosition as ProtoStepPosition
+import ink.proto.LinearEasingFunction
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.drawscope.Stroke as DrawStroke
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.cahier.R
+import com.example.cahier.developer.brushdesigner.ui.EnumDropdown
+import com.example.cahier.developer.brushdesigner.ui.NumericField
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import ink.proto.BrushBehavior as ProtoBrushBehavior
+import ink.proto.CubicBezierEasingFunction as ProtoCubicBezier
+import ink.proto.StepsEasingFunction as ProtoSteps
+import kotlin.math.ceil
+import kotlin.math.floor
+
+@Composable
+fun ResponseNodeFields(
+  responseNode: ProtoBrushBehavior.ResponseNode,
+  behaviorNode: ProtoBrushBehavior.Node,
+  onUpdate: (NodeData) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Column(modifier = modifier) {
+    CurvePreviewWidget(
+      responseNode = responseNode,
+      modifier = Modifier.padding(bottom = 8.dp)
+    )
+    ResponseCurveWidget(
+      responseNode = responseNode,
+      onResponseNodeChanged = {
+        onUpdate(
+          NodeData.Behavior(
+            behaviorNode.toBuilder().setResponseNode(it).build()
+          )
+        )
+      }
+    )
+  }
+}
+
+@Composable
+fun CurvePreviewWidget(
+  responseNode: ProtoBrushBehavior.ResponseNode,
+  modifier: Modifier = Modifier,
+) {
+  BoxWithConstraints(
+    modifier = modifier
+      .height(120.dp)
+      .fillMaxWidth()
+      .border(1.dp, MaterialTheme.colorScheme.outlineVariant)
+  ) {
+    val widthPx = constraints.maxWidth.toFloat()
+    val heightPx = constraints.maxHeight.toFloat()
+
+    val backgroundColor = MaterialTheme.colorScheme.surfaceContainerLow
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val outlineColor = MaterialTheme.colorScheme.outline
+    val outlineVariantColor = MaterialTheme.colorScheme.outlineVariant
+
+    Canvas(modifier = Modifier.fillMaxSize()) {
+      // Background and Grid
+      drawRect(backgroundColor)
+      val centerY = heightPx * 0.8f
+      val scaleY = heightPx * 0.6f
+
+      // Zero line
+      drawLine(outlineColor, Offset(0f, centerY), Offset(widthPx, centerY))
+      // One line
+      drawLine(outlineVariantColor, Offset(0f, centerY - scaleY), Offset(widthPx, centerY - scaleY))
+
+      val path = androidx.compose.ui.graphics.Path()
+      when (responseNode.responseCurveCase) {
+        ProtoBrushBehavior.ResponseNode.ResponseCurveCase.CUBIC_BEZIER_RESPONSE_CURVE -> {
+          val c = responseNode.cubicBezierResponseCurve
+          path.moveTo(0f, centerY)
+          path.cubicTo(
+            c.x1 * widthPx,
+            centerY - c.y1 * scaleY,
+            c.x2 * widthPx,
+            centerY - c.y2 * scaleY,
+            widthPx,
+            centerY - scaleY
+          )
+        }
+        ProtoBrushBehavior.ResponseNode.ResponseCurveCase.STEPS_RESPONSE_CURVE -> {
+          val s = responseNode.stepsResponseCurve
+          val steps = s.stepCount.coerceAtLeast(1)
+          val position = s.stepPosition
+          path.moveTo(0f, centerY)
+          val numSamples = 200
+          for (i in 0..numSamples) {
+            val x = i.toFloat() / numSamples
+            val yVal = evaluateSteps(x, steps, position)
+            val px = x * widthPx
+            val py = centerY - yVal * scaleY
+            if (i == 0) path.moveTo(px, py) else path.lineTo(px, py)
+          }
+        }
+        ProtoBrushBehavior.ResponseNode.ResponseCurveCase.LINEAR_RESPONSE_CURVE -> {
+          val l = responseNode.linearResponseCurve
+          val xs = l.xList
+          val ys = l.yList
+          path.moveTo(0f, centerY)
+          if (xs.isEmpty()) {
+            path.lineTo(widthPx, centerY - scaleY)
+          } else {
+            for (i in xs.indices) {
+              path.lineTo(xs[i] * widthPx, centerY - ys[i] * scaleY)
+            }
+            path.lineTo(widthPx, centerY - scaleY)
+          }
+        }
+        ProtoBrushBehavior.ResponseNode.ResponseCurveCase.PREDEFINED_RESPONSE_CURVE -> {
+          val func = responseNode.predefinedResponseCurve
+          when (func) {
+            ProtoPredefinedEasingFunction.PREDEFINED_EASING_LINEAR -> {
+              path.moveTo(0f, centerY)
+              path.lineTo(widthPx, centerY - scaleY)
+            }
+            ProtoPredefinedEasingFunction.PREDEFINED_EASING_STEP_START -> {
+              path.moveTo(0f, centerY - scaleY)
+              path.lineTo(widthPx, centerY - scaleY)
+            }
+            ProtoPredefinedEasingFunction.PREDEFINED_EASING_STEP_END -> {
+              path.moveTo(0f, centerY)
+              path.lineTo(widthPx, centerY)
+              path.lineTo(widthPx, centerY - scaleY)
+            }
+            else -> {
+              val (x1, y1, x2, y2) =
+                when (func) {
+                  ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE ->
+                    listOf(0.25f, 0.1f, 0.25f, 1f)
+                  ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_IN ->
+                    listOf(0.42f, 0f, 1f, 1f)
+                  ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_OUT ->
+                    listOf(0f, 0f, 0.58f, 1f)
+                  ProtoPredefinedEasingFunction.PREDEFINED_EASING_EASE_IN_OUT ->
+                    listOf(0.42f, 0f, 0.58f, 1f)
+                  else -> listOf(0f, 0f, 1f, 1f)
+                }
+              path.moveTo(0f, centerY)
+              path.cubicTo(
+                x1 * widthPx,
+                centerY - y1 * scaleY,
+                x2 * widthPx,
+                centerY - y2 * scaleY,
+                widthPx,
+                centerY - scaleY
+              )
+            }
+          }
+        }
+        else -> {
+          path.moveTo(0f, centerY)
+          path.lineTo(widthPx, centerY - scaleY)
+        }
+      }
+      drawPath(
+        path,
+        primaryColor,
+        style = DrawStroke(width = 3.dp.toPx())
+      )
+    }
+  }
+}
+
+private fun evaluateSteps(x: Float, n: Int, position: ProtoStepPosition): Float {
+  val xClamped = x.coerceIn(0f, 1f)
+  return when (position) {
+    ProtoStepPosition.STEP_POSITION_JUMP_START -> {
+      ceil(xClamped * n).coerceAtLeast(1f) / n
+    }
+    ProtoStepPosition.STEP_POSITION_JUMP_BOTH -> {
+      floor(xClamped * (n + 1) + 1f) / (n + 1)
+    }
+    ProtoStepPosition.STEP_POSITION_JUMP_NONE -> {
+      if (n <= 1) xClamped else floor(xClamped * (n - 1)) / (n - 1)
+    }
+    else -> {
+      floor(xClamped * n) / n
+    }
+  }
+}
+
+@Composable
+fun ResponseCurveWidget(
+  responseNode: ProtoBrushBehavior.ResponseNode,
+  onResponseNodeChanged: (ProtoBrushBehavior.ResponseNode) -> Unit,
+) {
+  val currentCase = responseNode.responseCurveCase
+  val tabs =
+    listOf(
+      ProtoBrushBehavior.ResponseNode.ResponseCurveCase.PREDEFINED_RESPONSE_CURVE,
+      ProtoBrushBehavior.ResponseNode.ResponseCurveCase.CUBIC_BEZIER_RESPONSE_CURVE,
+      ProtoBrushBehavior.ResponseNode.ResponseCurveCase.STEPS_RESPONSE_CURVE,
+      ProtoBrushBehavior.ResponseNode.ResponseCurveCase.LINEAR_RESPONSE_CURVE,
+    )
+
+  val selectedTabIndex = tabs.indexOf(currentCase).coerceAtLeast(0)
+
+  Column {
+    TabRow(selectedTabIndex = selectedTabIndex) {
+      tabs.forEachIndexed { index, case ->
+        Tab(
+          selected = selectedTabIndex == index,
+          onClick = {
+            if (currentCase != case) {
+              val builder = responseNode.toBuilder()
+              when (case) {
+                ProtoBrushBehavior.ResponseNode.ResponseCurveCase.PREDEFINED_RESPONSE_CURVE ->
+                  builder.setPredefinedResponseCurve(
+                    ProtoPredefinedEasingFunction.PREDEFINED_EASING_LINEAR
+                  )
+                ProtoBrushBehavior.ResponseNode.ResponseCurveCase.CUBIC_BEZIER_RESPONSE_CURVE ->
+                  builder.setCubicBezierResponseCurve(
+                    ProtoCubicBezier.newBuilder()
+                      .setX1(0.5f)
+                      .setY1(0f)
+                      .setX2(0.5f)
+                      .setY2(1f)
+                      .build()
+                  )
+                ProtoBrushBehavior.ResponseNode.ResponseCurveCase.STEPS_RESPONSE_CURVE ->
+                  builder.setStepsResponseCurve(
+                    ProtoSteps.newBuilder()
+                      .setStepCount(3)
+                      .setStepPosition(ProtoStepPosition.STEP_POSITION_JUMP_START)
+                      .build()
+                  )
+                ProtoBrushBehavior.ResponseNode.ResponseCurveCase.LINEAR_RESPONSE_CURVE ->
+                  builder.setLinearResponseCurve(
+                    LinearEasingFunction.getDefaultInstance()
+                  )
+                else -> {}
+              }
+              onResponseNodeChanged(builder.build())
+            }
+          },
+          text = { Text(stringResource(case.displayStringRId())) }
+        )
+      }
+    }
+
+    Box(
+      modifier =
+        Modifier.padding(vertical = 8.dp).border(1.dp, MaterialTheme.colorScheme.outlineVariant)
+    ) {
+      when (currentCase) {
+        ProtoBrushBehavior.ResponseNode.ResponseCurveCase.CUBIC_BEZIER_RESPONSE_CURVE ->
+          CubicBezierWidget(responseNode.cubicBezierResponseCurve) {
+            onResponseNodeChanged(responseNode.toBuilder().setCubicBezierResponseCurve(it).build())
+          }
+        ProtoBrushBehavior.ResponseNode.ResponseCurveCase.STEPS_RESPONSE_CURVE ->
+          StepsWidget(responseNode.stepsResponseCurve) {
+            onResponseNodeChanged(responseNode.toBuilder().setStepsResponseCurve(it).build())
+          }
+        ProtoBrushBehavior.ResponseNode.ResponseCurveCase.PREDEFINED_RESPONSE_CURVE ->
+          PredefinedFunctionWidget(responseNode.predefinedResponseCurve) {
+            onResponseNodeChanged(responseNode.toBuilder().setPredefinedResponseCurve(it).build())
+          }
+        ProtoBrushBehavior.ResponseNode.ResponseCurveCase.LINEAR_RESPONSE_CURVE ->
+          LinearWidget(responseNode.linearResponseCurve) {
+            onResponseNodeChanged(responseNode.toBuilder().setLinearResponseCurve(it).build())
+          }
+        else -> Text(stringResource(R.string.bg_unknown_curve_type), modifier = Modifier.padding(16.dp))
+      }
+    }
+  }
+}
+
+@Composable
+fun LinearWidget(
+  curve: LinearEasingFunction,
+  onCurveChanged: (LinearEasingFunction) -> Unit,
+) {
+  Column(modifier = Modifier.padding(8.dp)) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      Text(text = stringResource(R.string.bg_points), style = MaterialTheme.typography.titleSmall)
+      IconButton(
+        onClick = {
+          val builder = curve.toBuilder()
+          val newX = if (curve.xCount > 0) (curve.getX(curve.xCount - 1) + 1f) / 2f else 0.5f
+          val newY = if (curve.yCount > 0) (curve.getY(curve.yCount - 1) + 1f) / 2f else 0.5f
+          builder.addX(newX).addY(newY).build()
+          onCurveChanged(builder.build())
+        }
+      ) {
+        Icon(Icons.Default.Add, contentDescription = stringResource(R.string.bg_cd_add_point))
+      }
+    }
+
+    for (i in 0 until curve.xCount) {
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        Column(modifier = Modifier.weight(1f)) {
+          NumericField(
+            title = "X",
+            value = curve.getX(i),
+            limits = NumericLimits.standard(0f, 1f, 0.01f),
+            onValueChanged = { newValue ->
+              val builder = curve.toBuilder()
+              builder.setX(i, newValue)
+              onCurveChanged(builder.build())
+            }
+          )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+          NumericField(
+            title = "Y",
+            value = curve.getY(i),
+            limits = NumericLimits.standard(-2f, 2f, 0.01f),
+            onValueChanged = { newValue ->
+              val builder = curve.toBuilder()
+              builder.setY(i, newValue)
+              onCurveChanged(builder.build())
+            }
+          )
+        }
+        IconButton(
+          onClick = {
+            val newXs = curve.xList.toMutableList()
+            val newYs = curve.yList.toMutableList()
+            if (i < newXs.size && i < newYs.size) {
+              newXs.removeAt(i)
+              newYs.removeAt(i)
+            }
+            onCurveChanged(
+              curve.toBuilder()
+                .clearX().addAllX(newXs)
+                .clearY().addAllY(newYs)
+                .build()
+            )
+          }
+        ) {
+          Icon(Icons.Default.Remove, contentDescription = stringResource(R.string.bg_cd_remove_point))
+        }
+      }
+    }
+  }
+}
+
+@Composable
+fun CubicBezierWidget(curve: ProtoCubicBezier, onCurveChanged: (ProtoCubicBezier) -> Unit) {
+  Column(modifier = Modifier.padding(8.dp)) {
+    NumericField(title = "x1", value = curve.x1, limits = NumericLimits.standard(0f, 1f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setX1(it).build()) })
+    NumericField(title = "y1", value = curve.y1, limits = NumericLimits.standard(-2f, 2f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setY1(it).build()) })
+    NumericField(title = "x2", value = curve.x2, limits = NumericLimits.standard(0f, 1f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setX2(it).build()) })
+    NumericField(title = "y2", value = curve.y2, limits = NumericLimits.standard(-2f, 2f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setY2(it).build()) })
+  }
+}
+
+@Composable
+fun StepsWidget(curve: ProtoSteps, onCurveChanged: (ProtoSteps) -> Unit) {
+  Column(modifier = Modifier.padding(8.dp)) {
+    NumericField(
+      title = stringResource(R.string.bg_label_step_count),
+      value = curve.stepCount.toFloat(),
+      limits = NumericLimits.standard(1f, 20f, 1f),
+      onValueChanged = {
+        onCurveChanged(curve.toBuilder().setStepCount(it.toInt()).build())
+      }
+    )
+    EnumDropdown(
+      label = stringResource(R.string.bg_step_position),
+      currentValue = curve.stepPosition,
+      values = ProtoStepPosition.values().filter {
+        it != ProtoStepPosition.STEP_POSITION_UNSPECIFIED && it.ordinal >= 0
+      }.toList(),
+      displayName = { stringResource(it.displayStringRId()) },
+      onSelected = { position ->
+        onCurveChanged(curve.toBuilder().setStepPosition(position).build())
+      }
+    )
+  }
+}
+
+@Composable
+fun PredefinedFunctionWidget(
+  current: ProtoPredefinedEasingFunction,
+  onChanged: (ProtoPredefinedEasingFunction) -> Unit,
+) {
+  EnumDropdown(
+    label = stringResource(R.string.bg_predefined_function),
+    currentValue = current,
+    values = ProtoPredefinedEasingFunction.values().filter {
+      it != ProtoPredefinedEasingFunction.PREDEFINED_EASING_UNSPECIFIED && it.ordinal >= 0
+    }.toList(),
+    modifier = Modifier.padding(8.dp),
+    displayName = { stringResource(it.displayStringRId()) },
+    onSelected = { func ->
+      onChanged(func)
+    }
+  )
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ResponseNodeFields.kt
@@ -264,6 +264,7 @@ private fun evaluateSteps(x: Float, n: Int, position: ProtoStepPosition): Float 
 fun ResponseCurveWidget(
   responseNode: ProtoBrushBehavior.ResponseNode,
   onResponseNodeChanged: (ProtoBrushBehavior.ResponseNode) -> Unit,
+  modifier: Modifier = Modifier,
 ) {
   val currentCase = responseNode.responseCurveCase
   val tabs =
@@ -321,7 +322,7 @@ fun ResponseCurveWidget(
 
     Box(
       modifier =
-        Modifier.padding(vertical = 8.dp).border(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        modifier.padding(vertical = 8.dp).border(1.dp, MaterialTheme.colorScheme.outlineVariant)
     ) {
       when (currentCase) {
         ProtoBrushBehavior.ResponseNode.ResponseCurveCase.CUBIC_BEZIER_RESPONSE_CURVE ->
@@ -349,9 +350,10 @@ fun ResponseCurveWidget(
 @Composable
 fun LinearWidget(
   curve: LinearEasingFunction,
+  modifier: Modifier = Modifier,
   onCurveChanged: (LinearEasingFunction) -> Unit,
 ) {
-  Column(modifier = Modifier.padding(8.dp)) {
+  Column(modifier = modifier.padding(8.dp)) {
     Row(verticalAlignment = Alignment.CenterVertically) {
       Text(text = stringResource(R.string.bg_points), style = MaterialTheme.typography.titleSmall)
       IconButton(
@@ -418,8 +420,8 @@ fun LinearWidget(
 }
 
 @Composable
-fun CubicBezierWidget(curve: ProtoCubicBezier, onCurveChanged: (ProtoCubicBezier) -> Unit) {
-  Column(modifier = Modifier.padding(8.dp)) {
+fun CubicBezierWidget(curve: ProtoCubicBezier, modifier: Modifier = Modifier, onCurveChanged: (ProtoCubicBezier) -> Unit,) {
+  Column(modifier = modifier.padding(8.dp)) {
     NumericField(title = "x1", value = curve.x1, limits = NumericLimits(0f, 1f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setX1(it).build()) })
     NumericField(title = "y1", value = curve.y1, limits = NumericLimits(-2f, 2f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setY1(it).build()) })
     NumericField(title = "x2", value = curve.x2, limits = NumericLimits(0f, 1f, 0.01f), onValueChanged = { onCurveChanged(curve.toBuilder().setX2(it).build()) })
@@ -428,8 +430,8 @@ fun CubicBezierWidget(curve: ProtoCubicBezier, onCurveChanged: (ProtoCubicBezier
 }
 
 @Composable
-fun StepsWidget(curve: ProtoSteps, onCurveChanged: (ProtoSteps) -> Unit) {
-  Column(modifier = Modifier.padding(8.dp)) {
+fun StepsWidget(curve: ProtoSteps, modifier: Modifier = Modifier, onCurveChanged: (ProtoSteps) -> Unit,) {
+  Column(modifier = modifier.padding(8.dp)) {
     NumericField(
       title = stringResource(R.string.bg_label_step_count),
       value = curve.stepCount.toFloat(),
@@ -455,6 +457,7 @@ fun StepsWidget(curve: ProtoSteps, onCurveChanged: (ProtoSteps) -> Unit) {
 @Composable
 fun PredefinedFunctionWidget(
   current: ProtoPredefinedEasingFunction,
+  modifier: Modifier = Modifier,
   onChanged: (ProtoPredefinedEasingFunction) -> Unit,
 ) {
   EnumDropdown(
@@ -463,7 +466,7 @@ fun PredefinedFunctionWidget(
     values = ProtoPredefinedEasingFunction.values().filter {
       it != ProtoPredefinedEasingFunction.PREDEFINED_EASING_UNSPECIFIED && it.ordinal >= 0
     }.toList(),
-    modifier = Modifier.padding(8.dp),
+    modifier = modifier.padding(8.dp),
     displayName = { stringResource(it.displayStringRId()) },
     onSelected = { func ->
       onChanged(func)

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
@@ -88,10 +88,10 @@ fun SourceNodeFields(
         onDismissRequest = { expandedSource = false }
       ) {
         @Composable
-        fun SourceSection(label: String, sources: List<ProtoBrushBehavior.Source>) {
+        fun SourceSection(label: String, sources: List<ProtoBrushBehavior.Source>, modifier: Modifier = Modifier) {
           Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+            modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)
           ) {
             HorizontalDivider(modifier = Modifier.weight(1f))
             Text(

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
@@ -1,0 +1,223 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Help
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.cahier.R
+import com.example.cahier.developer.brushdesigner.ui.EnumDropdown
+import com.example.cahier.developer.brushgraph.ui.FieldWithTooltip
+import com.example.cahier.developer.brushdesigner.ui.NumericField
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.getNumericLimits
+import com.example.cahier.developer.brushgraph.ui.getTooltip
+import com.example.cahier.developer.brushgraph.ui.TooltipDialog
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import ink.proto.BrushBehavior as ProtoBrushBehavior
+
+@Composable
+fun SourceNodeFields(
+  sourceNode: ProtoBrushBehavior.SourceNode,
+  behaviorNode: ProtoBrushBehavior.Node,
+  onUpdate: (NodeData) -> Unit,
+  onDropdownEditComplete: () -> Unit,
+  onFieldEditComplete: () -> Unit,
+  textFieldsLocked: Boolean,
+  modifier: Modifier = Modifier
+) {
+  val limits = sourceNode.source.getNumericLimits()
+  var expandedSource by remember { mutableStateOf(false) }
+  var showSourceTooltip by remember { mutableStateOf(false) }
+  
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier.fillMaxWidth()
+  ) {
+    ExposedDropdownMenuBox(
+      expanded = expandedSource,
+      onExpandedChange = { expandedSource = it },
+      modifier = Modifier.weight(1f)
+    ) {
+      OutlinedTextField(
+        value = stringResource(sourceNode.source.displayStringRId()),
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(stringResource(R.string.bg_source)) },
+        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedSource) },
+        modifier = Modifier.menuAnchor().fillMaxWidth()
+      )
+      ExposedDropdownMenu(
+        expanded = expandedSource,
+        onDismissRequest = { expandedSource = false }
+      ) {
+        @Composable
+        fun SourceSection(label: String, sources: List<ProtoBrushBehavior.Source>) {
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+          ) {
+            HorizontalDivider(modifier = Modifier.weight(1f))
+            Text(
+              text = label,
+              style = MaterialTheme.typography.labelSmall,
+              color = MaterialTheme.colorScheme.outline,
+              modifier = Modifier.padding(horizontal = 8.dp)
+            )
+            HorizontalDivider(modifier = Modifier.weight(1f))
+          }
+          sources.forEach { source ->
+            DropdownMenuItem(
+              text = { Text(stringResource(source.displayStringRId())) },
+              onClick = {
+                val currentDisplayStart = if (sourceNode.source.isAngle()) Math.toDegrees(sourceNode.sourceValueRangeStart.toDouble()).toFloat() else sourceNode.sourceValueRangeStart
+                val currentDisplayEnd = if (sourceNode.source.isAngle()) Math.toDegrees(sourceNode.sourceValueRangeEnd.toDouble()).toFloat() else sourceNode.sourceValueRangeEnd
+
+                val newLimits = source.getNumericLimits()
+                val clampedDisplayStart = currentDisplayStart.coerceIn(newLimits.min, newLimits.max)
+                val clampedDisplayEnd = currentDisplayEnd.coerceIn(newLimits.min, newLimits.max)
+
+                val newProtoStart = if (source.isAngle()) Math.toRadians(clampedDisplayStart.toDouble()).toFloat() else clampedDisplayStart
+                val newProtoEnd = if (source.isAngle()) Math.toRadians(clampedDisplayEnd.toDouble()).toFloat() else clampedDisplayEnd
+
+                val needsClamp = source == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_INPUT_IN_SECONDS ||
+                                source == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_STROKE_END_IN_SECONDS
+                val newOor = if (needsClamp) ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP else sourceNode.sourceOutOfRangeBehavior
+                
+                onUpdate(
+                  NodeData.Behavior(
+                    behaviorNode.toBuilder()
+                      .setSourceNode(
+                        sourceNode.toBuilder()
+                          .setSource(source)
+                          .setSourceOutOfRangeBehavior(newOor)
+                          .setSourceValueRangeStart(newProtoStart)
+                          .setSourceValueRangeEnd(newProtoEnd)
+                          .build()
+                      )
+                      .build()
+                  )
+                )
+                onDropdownEditComplete()
+                expandedSource = false
+              }
+            )
+          }
+        }
+
+        SourceSection(stringResource(R.string.bg_section_input), SOURCES_INPUT)
+        SourceSection(stringResource(R.string.bg_section_movement), SOURCES_MOVEMENT)
+        SourceSection(stringResource(R.string.bg_section_distance), SOURCES_DISTANCE)
+        SourceSection(stringResource(R.string.bg_section_time), SOURCES_TIME)
+        SourceSection(stringResource(R.string.bg_section_acceleration), SOURCES_ACCELERATION)
+      }
+    }
+    IconButton(onClick = { showSourceTooltip = true }) {
+      Icon(Icons.AutoMirrored.Filled.Help, contentDescription = stringResource(R.string.bg_cd_help))
+    }
+  }
+  
+  if (showSourceTooltip) {
+    TooltipDialog(
+      title = stringResource(R.string.bg_title_source_format, stringResource(sourceNode.source.displayStringRId())),
+      text = stringResource(sourceNode.source.getTooltip()),
+      onDismiss = { showSourceTooltip = false }
+    )
+  }
+  val isAngleSource = sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TILT_IN_RADIANS ||
+                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TILT_X_IN_RADIANS ||
+                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TILT_Y_IN_RADIANS ||
+                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_DIRECTION_IN_RADIANS ||
+                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_ORIENTATION_IN_RADIANS ||
+                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_DIRECTION_ABOUT_ZERO_IN_RADIANS ||
+                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_ORIENTATION_ABOUT_ZERO_IN_RADIANS
+
+  val displayValueStart = if (isAngleSource) Math.toDegrees(sourceNode.sourceValueRangeStart.toDouble()).toFloat() else sourceNode.sourceValueRangeStart
+  val displayValueEnd = if (isAngleSource) Math.toDegrees(sourceNode.sourceValueRangeEnd.toDouble()).toFloat() else sourceNode.sourceValueRangeEnd
+
+  NumericField(
+    title = stringResource(R.string.bg_label_range_start),
+    value = displayValueStart,
+    limits = limits,
+    onValueChanged = {
+      val newValue = if (isAngleSource) Math.toRadians(it.toDouble()).toFloat() else it
+      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeStart(newValue).build()).build()))
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+  NumericField(
+    title = stringResource(R.string.bg_label_range_end),
+    value = displayValueEnd,
+    limits = limits,
+    onValueChanged = {
+      val newValue = if (isAngleSource) Math.toRadians(it.toDouble()).toFloat() else it
+      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeEnd(newValue).build()).build()))
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+  val isTimeSinceSource = sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_INPUT_IN_SECONDS ||
+                          sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_STROKE_END_IN_SECONDS
+  FieldWithTooltip(
+    tooltipTitle = stringResource(R.string.bg_title_out_of_range_behavior_format, stringResource(sourceNode.sourceOutOfRangeBehavior.displayStringRId())),
+    tooltipText = stringResource(sourceNode.sourceOutOfRangeBehavior.getTooltip())
+  ) {
+    EnumDropdown(
+      label = stringResource(R.string.bg_out_of_range_behavior),
+      currentValue = sourceNode.sourceOutOfRangeBehavior,
+      values = if (isTimeSinceSource) {
+          listOf(ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP)
+      } else {
+          ALL_OUT_OF_RANGE.toList()
+      },
+      displayName = { stringResource(it.displayStringRId()) },
+      onSelected = { oor ->
+        onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceOutOfRangeBehavior(oor).build()).build()))
+        onDropdownEditComplete()
+      }
+    )
+  }
+  if (isTimeSinceSource) {
+    Text(
+      text = stringResource(R.string.bg_msg_source_clamp_only),
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.secondary,
+      modifier = Modifier.padding(top = 4.dp)
+    )
+  }
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
@@ -159,28 +159,21 @@ fun SourceNodeFields(
       onDismiss = { showSourceTooltip = false }
     )
   }
-  val isAngleSource = sourceNode.source.isAngle()
-
-  val displayValueStart = if (isAngleSource) Math.toDegrees(sourceNode.sourceValueRangeStart.toDouble()).toFloat() else sourceNode.sourceValueRangeStart
-  val displayValueEnd = if (isAngleSource) Math.toDegrees(sourceNode.sourceValueRangeEnd.toDouble()).toFloat() else sourceNode.sourceValueRangeEnd
-
   NumericField(
     title = stringResource(R.string.bg_label_range_start),
-    value = displayValueStart,
+    value = sourceNode.sourceValueRangeStart,
     limits = limits,
     onValueChanged = {
-      val newValue = if (isAngleSource) Math.toRadians(it.toDouble()).toFloat() else it
-      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeStart(newValue).build()).build()))
+      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeStart(it).build()).build()))
     },
     onValueChangeFinished = onFieldEditComplete
   )
   NumericField(
     title = stringResource(R.string.bg_label_range_end),
-    value = displayValueEnd,
+    value = sourceNode.sourceValueRangeEnd,
     limits = limits,
     onValueChanged = {
-      val newValue = if (isAngleSource) Math.toRadians(it.toDouble()).toFloat() else it
-      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeEnd(newValue).build()).build()))
+      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeEnd(it).build()).build()))
     },
     onValueChangeFinished = onFieldEditComplete
   )

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
@@ -116,8 +116,7 @@ fun SourceNodeFields(
                 val newProtoStart = if (source.isAngle()) Math.toRadians(clampedDisplayStart.toDouble()).toFloat() else clampedDisplayStart
                 val newProtoEnd = if (source.isAngle()) Math.toRadians(clampedDisplayEnd.toDouble()).toFloat() else clampedDisplayEnd
 
-                val needsClamp = source == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_INPUT_IN_SECONDS ||
-                                source == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_STROKE_END_IN_SECONDS
+                val needsClamp = source.isTimeSince()
                 val newOor = if (needsClamp) ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP else sourceNode.sourceOutOfRangeBehavior
                 
                 onUpdate(
@@ -160,13 +159,7 @@ fun SourceNodeFields(
       onDismiss = { showSourceTooltip = false }
     )
   }
-  val isAngleSource = sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TILT_IN_RADIANS ||
-                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TILT_X_IN_RADIANS ||
-                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TILT_Y_IN_RADIANS ||
-                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_DIRECTION_IN_RADIANS ||
-                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_ORIENTATION_IN_RADIANS ||
-                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_DIRECTION_ABOUT_ZERO_IN_RADIANS ||
-                      sourceNode.source == ProtoBrushBehavior.Source.SOURCE_ORIENTATION_ABOUT_ZERO_IN_RADIANS
+  val isAngleSource = sourceNode.source.isAngle()
 
   val displayValueStart = if (isAngleSource) Math.toDegrees(sourceNode.sourceValueRangeStart.toDouble()).toFloat() else sourceNode.sourceValueRangeStart
   val displayValueEnd = if (isAngleSource) Math.toDegrees(sourceNode.sourceValueRangeEnd.toDouble()).toFloat() else sourceNode.sourceValueRangeEnd
@@ -191,8 +184,7 @@ fun SourceNodeFields(
     },
     onValueChangeFinished = onFieldEditComplete
   )
-  val isTimeSinceSource = sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_INPUT_IN_SECONDS ||
-                          sourceNode.source == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_STROKE_END_IN_SECONDS
+  val isTimeSinceSource = sourceNode.source.isTimeSince()
   FieldWithTooltip(
     tooltipTitle = stringResource(R.string.bg_title_out_of_range_behavior_format, stringResource(sourceNode.sourceOutOfRangeBehavior.displayStringRId())),
     tooltipText = stringResource(sourceNode.sourceOutOfRangeBehavior.getTooltip())
@@ -220,4 +212,9 @@ fun SourceNodeFields(
       modifier = Modifier.padding(top = 4.dp)
     )
   }
+}
+
+private fun ProtoBrushBehavior.Source.isTimeSince(): Boolean {
+  return this == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_INPUT_IN_SECONDS ||
+         this == ProtoBrushBehavior.Source.SOURCE_TIME_SINCE_STROKE_END_IN_SECONDS
 }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/SourceNodeFields.kt
@@ -17,6 +17,7 @@
 
 package com.example.cahier.developer.brushgraph.ui.fields
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -66,144 +67,146 @@ fun SourceNodeFields(
   var expandedSource by remember { mutableStateOf(false) }
   var showSourceTooltip by remember { mutableStateOf(false) }
   
-  Row(
-    verticalAlignment = Alignment.CenterVertically,
-    modifier = modifier.fillMaxWidth()
-  ) {
-    ExposedDropdownMenuBox(
-      expanded = expandedSource,
-      onExpandedChange = { expandedSource = it },
-      modifier = Modifier.weight(1f)
+  Column(modifier = modifier) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.fillMaxWidth()
     ) {
-      OutlinedTextField(
-        value = stringResource(sourceNode.source.displayStringRId()),
-        onValueChange = {},
-        readOnly = true,
-        label = { Text(stringResource(R.string.bg_source)) },
-        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedSource) },
-        modifier = Modifier.menuAnchor().fillMaxWidth()
-      )
-      ExposedDropdownMenu(
+      ExposedDropdownMenuBox(
         expanded = expandedSource,
-        onDismissRequest = { expandedSource = false }
+        onExpandedChange = { expandedSource = it },
+        modifier = Modifier.weight(1f)
       ) {
-        @Composable
-        fun SourceSection(label: String, sources: List<ProtoBrushBehavior.Source>, modifier: Modifier = Modifier) {
-          Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)
-          ) {
-            HorizontalDivider(modifier = Modifier.weight(1f))
-            Text(
-              text = label,
-              style = MaterialTheme.typography.labelSmall,
-              color = MaterialTheme.colorScheme.outline,
-              modifier = Modifier.padding(horizontal = 8.dp)
-            )
-            HorizontalDivider(modifier = Modifier.weight(1f))
-          }
-          sources.forEach { source ->
-            DropdownMenuItem(
-              text = { Text(stringResource(source.displayStringRId())) },
-              onClick = {
-                val currentDisplayStart = if (sourceNode.source.isAngle()) Math.toDegrees(sourceNode.sourceValueRangeStart.toDouble()).toFloat() else sourceNode.sourceValueRangeStart
-                val currentDisplayEnd = if (sourceNode.source.isAngle()) Math.toDegrees(sourceNode.sourceValueRangeEnd.toDouble()).toFloat() else sourceNode.sourceValueRangeEnd
+        OutlinedTextField(
+          value = stringResource(sourceNode.source.displayStringRId()),
+          onValueChange = {},
+          readOnly = true,
+          label = { Text(stringResource(R.string.bg_source)) },
+          trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedSource) },
+          modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+          expanded = expandedSource,
+          onDismissRequest = { expandedSource = false }
+        ) {
+          @Composable
+          fun SourceSection(label: String, sources: List<ProtoBrushBehavior.Source>, modifier: Modifier = Modifier) {
+            Row(
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+            ) {
+              HorizontalDivider(modifier = Modifier.weight(1f))
+              Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+                modifier = Modifier.padding(horizontal = 8.dp)
+              )
+              HorizontalDivider(modifier = Modifier.weight(1f))
+            }
+            sources.forEach { source ->
+              DropdownMenuItem(
+                text = { Text(stringResource(source.displayStringRId())) },
+                onClick = {
+                  val currentDisplayStart = if (sourceNode.source.isAngle()) Math.toDegrees(sourceNode.sourceValueRangeStart.toDouble()).toFloat() else sourceNode.sourceValueRangeStart
+                  val currentDisplayEnd = if (sourceNode.source.isAngle()) Math.toDegrees(sourceNode.sourceValueRangeEnd.toDouble()).toFloat() else sourceNode.sourceValueRangeEnd
 
-                val newLimits = source.getNumericLimits()
-                val clampedDisplayStart = currentDisplayStart.coerceIn(newLimits.min, newLimits.max)
-                val clampedDisplayEnd = currentDisplayEnd.coerceIn(newLimits.min, newLimits.max)
+                  val newLimits = source.getNumericLimits()
+                  val clampedDisplayStart = currentDisplayStart.coerceIn(newLimits.min, newLimits.max)
+                  val clampedDisplayEnd = currentDisplayEnd.coerceIn(newLimits.min, newLimits.max)
 
-                val newProtoStart = if (source.isAngle()) Math.toRadians(clampedDisplayStart.toDouble()).toFloat() else clampedDisplayStart
-                val newProtoEnd = if (source.isAngle()) Math.toRadians(clampedDisplayEnd.toDouble()).toFloat() else clampedDisplayEnd
+                  val newProtoStart = if (source.isAngle()) Math.toRadians(clampedDisplayStart.toDouble()).toFloat() else clampedDisplayStart
+                  val newProtoEnd = if (source.isAngle()) Math.toRadians(clampedDisplayEnd.toDouble()).toFloat() else clampedDisplayEnd
 
-                val needsClamp = source.isTimeSince()
-                val newOor = if (needsClamp) ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP else sourceNode.sourceOutOfRangeBehavior
-                
-                onUpdate(
-                  NodeData.Behavior(
-                    behaviorNode.toBuilder()
-                      .setSourceNode(
-                        sourceNode.toBuilder()
-                          .setSource(source)
-                          .setSourceOutOfRangeBehavior(newOor)
-                          .setSourceValueRangeStart(newProtoStart)
-                          .setSourceValueRangeEnd(newProtoEnd)
-                          .build()
-                      )
-                      .build()
+                  val needsClamp = source.isTimeSince()
+                  val newOor = if (needsClamp) ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP else sourceNode.sourceOutOfRangeBehavior
+                  
+                  onUpdate(
+                    NodeData.Behavior(
+                      behaviorNode.toBuilder()
+                        .setSourceNode(
+                          sourceNode.toBuilder()
+                            .setSource(source)
+                            .setSourceOutOfRangeBehavior(newOor)
+                            .setSourceValueRangeStart(newProtoStart)
+                            .setSourceValueRangeEnd(newProtoEnd)
+                            .build()
+                        )
+                        .build()
+                    )
                   )
-                )
-                onDropdownEditComplete()
-                expandedSource = false
-              }
-            )
+                  onDropdownEditComplete()
+                  expandedSource = false
+                }
+              )
+            }
           }
-        }
 
-        SourceSection(stringResource(R.string.bg_section_input), SOURCES_INPUT)
-        SourceSection(stringResource(R.string.bg_section_movement), SOURCES_MOVEMENT)
-        SourceSection(stringResource(R.string.bg_section_distance), SOURCES_DISTANCE)
-        SourceSection(stringResource(R.string.bg_section_time), SOURCES_TIME)
-        SourceSection(stringResource(R.string.bg_section_acceleration), SOURCES_ACCELERATION)
+          SourceSection(stringResource(R.string.bg_section_input), SOURCES_INPUT)
+          SourceSection(stringResource(R.string.bg_section_movement), SOURCES_MOVEMENT)
+          SourceSection(stringResource(R.string.bg_section_distance), SOURCES_DISTANCE)
+          SourceSection(stringResource(R.string.bg_section_time), SOURCES_TIME)
+          SourceSection(stringResource(R.string.bg_section_acceleration), SOURCES_ACCELERATION)
+        }
+      }
+      IconButton(onClick = { showSourceTooltip = true }) {
+        Icon(Icons.AutoMirrored.Filled.Help, contentDescription = stringResource(R.string.bg_cd_help))
       }
     }
-    IconButton(onClick = { showSourceTooltip = true }) {
-      Icon(Icons.AutoMirrored.Filled.Help, contentDescription = stringResource(R.string.bg_cd_help))
+    
+    if (showSourceTooltip) {
+      TooltipDialog(
+        title = stringResource(R.string.bg_title_source_format, stringResource(sourceNode.source.displayStringRId())),
+        text = stringResource(sourceNode.source.getTooltip()),
+        onDismiss = { showSourceTooltip = false }
+      )
     }
-  }
-  
-  if (showSourceTooltip) {
-    TooltipDialog(
-      title = stringResource(R.string.bg_title_source_format, stringResource(sourceNode.source.displayStringRId())),
-      text = stringResource(sourceNode.source.getTooltip()),
-      onDismiss = { showSourceTooltip = false }
-    )
-  }
-  NumericField(
-    title = stringResource(R.string.bg_label_range_start),
-    value = sourceNode.sourceValueRangeStart,
-    limits = limits,
-    onValueChanged = {
-      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeStart(it).build()).build()))
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
-  NumericField(
-    title = stringResource(R.string.bg_label_range_end),
-    value = sourceNode.sourceValueRangeEnd,
-    limits = limits,
-    onValueChanged = {
-      onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeEnd(it).build()).build()))
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
-  val isTimeSinceSource = sourceNode.source.isTimeSince()
-  FieldWithTooltip(
-    tooltipTitle = stringResource(R.string.bg_title_out_of_range_behavior_format, stringResource(sourceNode.sourceOutOfRangeBehavior.displayStringRId())),
-    tooltipText = stringResource(sourceNode.sourceOutOfRangeBehavior.getTooltip())
-  ) {
-    EnumDropdown(
-      label = stringResource(R.string.bg_out_of_range_behavior),
-      currentValue = sourceNode.sourceOutOfRangeBehavior,
-      values = if (isTimeSinceSource) {
-          listOf(ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP)
-      } else {
-          ALL_OUT_OF_RANGE.toList()
+    NumericField(
+      title = stringResource(R.string.bg_label_range_start),
+      value = sourceNode.sourceValueRangeStart,
+      limits = limits,
+      onValueChanged = {
+        onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeStart(it).build()).build()))
       },
-      displayName = { stringResource(it.displayStringRId()) },
-      onSelected = { oor ->
-        onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceOutOfRangeBehavior(oor).build()).build()))
-        onDropdownEditComplete()
-      }
+      onValueChangeFinished = onFieldEditComplete
     )
-  }
-  if (isTimeSinceSource) {
-    Text(
-      text = stringResource(R.string.bg_msg_source_clamp_only),
-      style = MaterialTheme.typography.bodySmall,
-      color = MaterialTheme.colorScheme.secondary,
-      modifier = Modifier.padding(top = 4.dp)
+    NumericField(
+      title = stringResource(R.string.bg_label_range_end),
+      value = sourceNode.sourceValueRangeEnd,
+      limits = limits,
+      onValueChanged = {
+        onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceValueRangeEnd(it).build()).build()))
+      },
+      onValueChangeFinished = onFieldEditComplete
     )
+    val isTimeSinceSource = sourceNode.source.isTimeSince()
+    FieldWithTooltip(
+      tooltipTitle = stringResource(R.string.bg_title_out_of_range_behavior_format, stringResource(sourceNode.sourceOutOfRangeBehavior.displayStringRId())),
+      tooltipText = stringResource(sourceNode.sourceOutOfRangeBehavior.getTooltip())
+    ) {
+      EnumDropdown(
+        label = stringResource(R.string.bg_out_of_range_behavior),
+        currentValue = sourceNode.sourceOutOfRangeBehavior,
+        values = if (isTimeSinceSource) {
+            listOf(ProtoBrushBehavior.OutOfRange.OUT_OF_RANGE_CLAMP)
+        } else {
+            ALL_OUT_OF_RANGE.toList()
+        },
+        displayName = { stringResource(it.displayStringRId()) },
+        onSelected = { oor ->
+          onUpdate(NodeData.Behavior(behaviorNode.toBuilder().setSourceNode(sourceNode.toBuilder().setSourceOutOfRangeBehavior(oor).build()).build()))
+          onDropdownEditComplete()
+        }
+      )
+    }
+    if (isTimeSinceSource) {
+      Text(
+        text = stringResource(R.string.bg_msg_source_clamp_only),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.secondary,
+        modifier = Modifier.padding(top = 4.dp)
+      )
+    }
   }
 }
 

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TargetNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TargetNodeFields.kt
@@ -85,10 +85,10 @@ fun TargetNodeFields(
         onDismissRequest = { expandedTarget = false }
       ) {
         @Composable
-        fun TargetSection(label: String, targets: List<ProtoBrushBehavior.Target>) {
+        fun TargetSection(label: String, targets: List<ProtoBrushBehavior.Target>, modifier: Modifier = Modifier,) {
           Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+            modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)
           ) {
             HorizontalDivider(modifier = Modifier.weight(1f))
             Text(

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TargetNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TargetNodeFields.kt
@@ -1,0 +1,182 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Help
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.cahier.R
+import com.example.cahier.developer.brushdesigner.ui.NumericField
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.getNumericLimits
+import com.example.cahier.developer.brushgraph.ui.getTooltip
+import com.example.cahier.developer.brushgraph.ui.TooltipDialog
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import ink.proto.BrushBehavior as ProtoBrushBehavior
+
+@Composable
+fun TargetNodeFields(
+  targetNode: ProtoBrushBehavior.TargetNode,
+  behaviorNode: ProtoBrushBehavior.Node,
+  onUpdate: (NodeData) -> Unit,
+  onFieldEditComplete: () -> Unit,
+  onDropdownEditComplete: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  val limits = targetNode.target.getNumericLimits()
+  var expandedTarget by remember { mutableStateOf(false) }
+  var showTargetTooltip by remember { mutableStateOf(false) }
+  
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier.fillMaxWidth()
+  ) {
+    ExposedDropdownMenuBox(
+      expanded = expandedTarget,
+      onExpandedChange = { expandedTarget = it },
+      modifier = Modifier.weight(1f)
+    ) {
+      OutlinedTextField(
+        value = stringResource(targetNode.target.displayStringRId()),
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(stringResource(R.string.bg_target)) },
+        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedTarget) },
+        modifier = Modifier.menuAnchor().fillMaxWidth()
+      )
+      ExposedDropdownMenu(
+        expanded = expandedTarget,
+        onDismissRequest = { expandedTarget = false }
+      ) {
+        @Composable
+        fun TargetSection(label: String, targets: List<ProtoBrushBehavior.Target>) {
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+          ) {
+            HorizontalDivider(modifier = Modifier.weight(1f))
+            Text(
+              text = label,
+              style = MaterialTheme.typography.labelSmall,
+              color = MaterialTheme.colorScheme.outline,
+              modifier = Modifier.padding(horizontal = 8.dp)
+            )
+            HorizontalDivider(modifier = Modifier.weight(1f))
+          }
+          targets.forEach { target ->
+            DropdownMenuItem(
+              text = { Text(stringResource(target.displayStringRId())) },
+              onClick = {
+                val currentDisplayStart = if (targetNode.target.isAngle()) Math.toDegrees(targetNode.targetModifierRangeStart.toDouble()).toFloat() else targetNode.targetModifierRangeStart
+                val currentDisplayEnd = if (targetNode.target.isAngle()) Math.toDegrees(targetNode.targetModifierRangeEnd.toDouble()).toFloat() else targetNode.targetModifierRangeEnd
+
+                val newLimits = target.getNumericLimits()
+                val clampedDisplayStart = currentDisplayStart.coerceIn(newLimits.min, newLimits.max)
+                val clampedDisplayEnd = currentDisplayEnd.coerceIn(newLimits.min, newLimits.max)
+
+                val newProtoStart = if (target.isAngle()) Math.toRadians(clampedDisplayStart.toDouble()).toFloat() else clampedDisplayStart
+                val newProtoEnd = if (target.isAngle()) Math.toRadians(clampedDisplayEnd.toDouble()).toFloat() else clampedDisplayEnd
+
+                onUpdate(
+                  NodeData.Behavior(
+                    behaviorNode.toBuilder()
+                      .setTargetNode(
+                        targetNode.toBuilder()
+                          .setTarget(target)
+                          .setTargetModifierRangeStart(newProtoStart)
+                          .setTargetModifierRangeEnd(newProtoEnd)
+                          .build()
+                      )
+                      .build()
+                  )
+                )
+                onDropdownEditComplete()
+                expandedTarget = false
+              }
+            )
+          }
+        }
+
+        TargetSection(stringResource(R.string.bg_section_size_shape), TARGETS_SIZE_SHAPE)
+        TargetSection(stringResource(R.string.bg_section_position), TARGETS_POSITION)
+        TargetSection(stringResource(R.string.bg_section_color_opacity), TARGETS_COLOR_OPACITY)
+      }
+    }
+    IconButton(onClick = { showTargetTooltip = true }) {
+      Icon(Icons.AutoMirrored.Filled.Help, contentDescription = stringResource(R.string.bg_cd_help))
+    }
+  }
+  if (showTargetTooltip) {
+    TooltipDialog(
+      title = stringResource(R.string.bg_title_target_format, stringResource(targetNode.target.displayStringRId())),
+      text = stringResource(targetNode.target.getTooltip()),
+      onDismiss = { showTargetTooltip = false }
+    )
+  }
+  NumericField(
+    title = stringResource(R.string.bg_label_range_start),
+    value = targetNode.targetModifierRangeStart,
+    limits = limits,
+    onValueChanged = {
+      onUpdate(
+        NodeData.Behavior(
+          behaviorNode.toBuilder()
+            .setTargetNode(targetNode.toBuilder().setTargetModifierRangeStart(it).build())
+            .build()
+        )
+      )
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+  NumericField(
+    title = stringResource(R.string.bg_label_range_end),
+    value = targetNode.targetModifierRangeEnd,
+    limits = limits,
+    onValueChanged = {
+      onUpdate(
+        NodeData.Behavior(
+          behaviorNode.toBuilder()
+            .setTargetNode(targetNode.toBuilder().setTargetModifierRangeEnd(it).build())
+            .build()
+        )
+      )
+    },
+    onValueChangeFinished = onFieldEditComplete
+  )
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TargetNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TargetNodeFields.kt
@@ -17,6 +17,7 @@
 
 package com.example.cahier.developer.brushgraph.ui.fields
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -63,120 +64,122 @@ fun TargetNodeFields(
   var expandedTarget by remember { mutableStateOf(false) }
   var showTargetTooltip by remember { mutableStateOf(false) }
   
-  Row(
-    verticalAlignment = Alignment.CenterVertically,
-    modifier = modifier.fillMaxWidth()
-  ) {
-    ExposedDropdownMenuBox(
-      expanded = expandedTarget,
-      onExpandedChange = { expandedTarget = it },
-      modifier = Modifier.weight(1f)
+  Column(modifier = modifier) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.fillMaxWidth()
     ) {
-      OutlinedTextField(
-        value = stringResource(targetNode.target.displayStringRId()),
-        onValueChange = {},
-        readOnly = true,
-        label = { Text(stringResource(R.string.bg_target)) },
-        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedTarget) },
-        modifier = Modifier.menuAnchor().fillMaxWidth()
-      )
-      ExposedDropdownMenu(
+      ExposedDropdownMenuBox(
         expanded = expandedTarget,
-        onDismissRequest = { expandedTarget = false }
+        onExpandedChange = { expandedTarget = it },
+        modifier = Modifier.weight(1f)
       ) {
-        @Composable
-        fun TargetSection(label: String, targets: List<ProtoBrushBehavior.Target>, modifier: Modifier = Modifier,) {
-          Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)
-          ) {
-            HorizontalDivider(modifier = Modifier.weight(1f))
-            Text(
-              text = label,
-              style = MaterialTheme.typography.labelSmall,
-              color = MaterialTheme.colorScheme.outline,
-              modifier = Modifier.padding(horizontal = 8.dp)
-            )
-            HorizontalDivider(modifier = Modifier.weight(1f))
-          }
-          targets.forEach { target ->
-            DropdownMenuItem(
-              text = { Text(stringResource(target.displayStringRId())) },
-              onClick = {
-                val currentDisplayStart = if (targetNode.target.isAngle()) Math.toDegrees(targetNode.targetModifierRangeStart.toDouble()).toFloat() else targetNode.targetModifierRangeStart
-                val currentDisplayEnd = if (targetNode.target.isAngle()) Math.toDegrees(targetNode.targetModifierRangeEnd.toDouble()).toFloat() else targetNode.targetModifierRangeEnd
+        OutlinedTextField(
+          value = stringResource(targetNode.target.displayStringRId()),
+          onValueChange = {},
+          readOnly = true,
+          label = { Text(stringResource(R.string.bg_target)) },
+          trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedTarget) },
+          modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+          expanded = expandedTarget,
+          onDismissRequest = { expandedTarget = false }
+        ) {
+          @Composable
+          fun TargetSection(label: String, targets: List<ProtoBrushBehavior.Target>, modifier: Modifier = Modifier,) {
+            Row(
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+            ) {
+              HorizontalDivider(modifier = Modifier.weight(1f))
+              Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+                modifier = Modifier.padding(horizontal = 8.dp)
+              )
+              HorizontalDivider(modifier = Modifier.weight(1f))
+            }
+            targets.forEach { target ->
+              DropdownMenuItem(
+                text = { Text(stringResource(target.displayStringRId())) },
+                onClick = {
+                  val currentDisplayStart = if (targetNode.target.isAngle()) Math.toDegrees(targetNode.targetModifierRangeStart.toDouble()).toFloat() else targetNode.targetModifierRangeStart
+                  val currentDisplayEnd = if (targetNode.target.isAngle()) Math.toDegrees(targetNode.targetModifierRangeEnd.toDouble()).toFloat() else targetNode.targetModifierRangeEnd
 
-                val newLimits = target.getNumericLimits()
-                val clampedDisplayStart = currentDisplayStart.coerceIn(newLimits.min, newLimits.max)
-                val clampedDisplayEnd = currentDisplayEnd.coerceIn(newLimits.min, newLimits.max)
+                  val newLimits = target.getNumericLimits()
+                  val clampedDisplayStart = currentDisplayStart.coerceIn(newLimits.min, newLimits.max)
+                  val clampedDisplayEnd = currentDisplayEnd.coerceIn(newLimits.min, newLimits.max)
 
-                val newProtoStart = if (target.isAngle()) Math.toRadians(clampedDisplayStart.toDouble()).toFloat() else clampedDisplayStart
-                val newProtoEnd = if (target.isAngle()) Math.toRadians(clampedDisplayEnd.toDouble()).toFloat() else clampedDisplayEnd
+                  val newProtoStart = if (target.isAngle()) Math.toRadians(clampedDisplayStart.toDouble()).toFloat() else clampedDisplayStart
+                  val newProtoEnd = if (target.isAngle()) Math.toRadians(clampedDisplayEnd.toDouble()).toFloat() else clampedDisplayEnd
 
-                onUpdate(
-                  NodeData.Behavior(
-                    behaviorNode.toBuilder()
-                      .setTargetNode(
-                        targetNode.toBuilder()
-                          .setTarget(target)
-                          .setTargetModifierRangeStart(newProtoStart)
-                          .setTargetModifierRangeEnd(newProtoEnd)
-                          .build()
-                      )
-                      .build()
+                  onUpdate(
+                    NodeData.Behavior(
+                      behaviorNode.toBuilder()
+                        .setTargetNode(
+                          targetNode.toBuilder()
+                            .setTarget(target)
+                            .setTargetModifierRangeStart(newProtoStart)
+                            .setTargetModifierRangeEnd(newProtoEnd)
+                            .build()
+                        )
+                        .build()
+                    )
                   )
-                )
-                onDropdownEditComplete()
-                expandedTarget = false
-              }
-            )
+                  onDropdownEditComplete()
+                  expandedTarget = false
+                }
+              )
+            }
           }
-        }
 
-        TargetSection(stringResource(R.string.bg_section_size_shape), TARGETS_SIZE_SHAPE)
-        TargetSection(stringResource(R.string.bg_section_position), TARGETS_POSITION)
-        TargetSection(stringResource(R.string.bg_section_color_opacity), TARGETS_COLOR_OPACITY)
+          TargetSection(stringResource(R.string.bg_section_size_shape), TARGETS_SIZE_SHAPE)
+          TargetSection(stringResource(R.string.bg_section_position), TARGETS_POSITION)
+          TargetSection(stringResource(R.string.bg_section_color_opacity), TARGETS_COLOR_OPACITY)
+        }
+      }
+      IconButton(onClick = { showTargetTooltip = true }) {
+        Icon(Icons.AutoMirrored.Filled.Help, contentDescription = stringResource(R.string.bg_cd_help))
       }
     }
-    IconButton(onClick = { showTargetTooltip = true }) {
-      Icon(Icons.AutoMirrored.Filled.Help, contentDescription = stringResource(R.string.bg_cd_help))
+    if (showTargetTooltip) {
+      TooltipDialog(
+        title = stringResource(R.string.bg_title_target_format, stringResource(targetNode.target.displayStringRId())),
+        text = stringResource(targetNode.target.getTooltip()),
+        onDismiss = { showTargetTooltip = false }
+      )
     }
-  }
-  if (showTargetTooltip) {
-    TooltipDialog(
-      title = stringResource(R.string.bg_title_target_format, stringResource(targetNode.target.displayStringRId())),
-      text = stringResource(targetNode.target.getTooltip()),
-      onDismiss = { showTargetTooltip = false }
+    NumericField(
+      title = stringResource(R.string.bg_label_range_start),
+      value = targetNode.targetModifierRangeStart,
+      limits = limits,
+      onValueChanged = {
+        onUpdate(
+          NodeData.Behavior(
+            behaviorNode.toBuilder()
+              .setTargetNode(targetNode.toBuilder().setTargetModifierRangeStart(it).build())
+              .build()
+          )
+        )
+      },
+      onValueChangeFinished = onFieldEditComplete
+    )
+    NumericField(
+      title = stringResource(R.string.bg_label_range_end),
+      value = targetNode.targetModifierRangeEnd,
+      limits = limits,
+      onValueChanged = {
+        onUpdate(
+          NodeData.Behavior(
+            behaviorNode.toBuilder()
+              .setTargetNode(targetNode.toBuilder().setTargetModifierRangeEnd(it).build())
+              .build()
+          )
+        )
+      },
+      onValueChangeFinished = onFieldEditComplete
     )
   }
-  NumericField(
-    title = stringResource(R.string.bg_label_range_start),
-    value = targetNode.targetModifierRangeStart,
-    limits = limits,
-    onValueChanged = {
-      onUpdate(
-        NodeData.Behavior(
-          behaviorNode.toBuilder()
-            .setTargetNode(targetNode.toBuilder().setTargetModifierRangeStart(it).build())
-            .build()
-        )
-      )
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
-  NumericField(
-    title = stringResource(R.string.bg_label_range_end),
-    value = targetNode.targetModifierRangeEnd,
-    limits = limits,
-    onValueChanged = {
-      onUpdate(
-        NodeData.Behavior(
-          behaviorNode.toBuilder()
-            .setTargetNode(targetNode.toBuilder().setTargetModifierRangeEnd(it).build())
-            .build()
-        )
-      )
-    },
-    onValueChangeFinished = onFieldEditComplete
-  )
 }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TextureLayerNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TextureLayerNodeFields.kt
@@ -110,13 +110,13 @@ fun TextureLayerNodeFields(
       NumericField(
         title = stringResource(R.string.bg_label_size_x),
         value = layer.sizeX,
-        limits = NumericLimits.standard(0.1f, 1000f, 0.1f),
+        limits = NumericLimits(0.1f, 1000f, 0.1f),
         onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setSizeX(it).build())) }
       )
       NumericField(
         title = stringResource(R.string.bg_label_size_y),
         value = layer.sizeY,
-        limits = NumericLimits.standard(0.1f, 1000f, 0.1f),
+        limits = NumericLimits(0.1f, 1000f, 0.1f),
         onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setSizeY(it).build())) }
       )
       FieldWithTooltip(
@@ -163,13 +163,13 @@ fun TextureLayerNodeFields(
     NumericField(
       title = stringResource(R.string.bg_label_offset_x),
       value = layer.offsetX,
-      limits = NumericLimits.standard(-1f, 1f, 0.01f),
+      limits = NumericLimits(-1f, 1f, 0.01f),
       onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setOffsetX(it).build())) }
     )
     NumericField(
       title = stringResource(R.string.bg_label_offset_y),
       value = layer.offsetY,
-      limits = NumericLimits.standard(-1f, 1f, 0.01f),
+      limits = NumericLimits(-1f, 1f, 0.01f),
       onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setOffsetY(it).build())) }
     )
     NumericField(

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TextureLayerNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TextureLayerNodeFields.kt
@@ -137,32 +137,6 @@ fun TextureLayerNodeFields(
           }
         )
       }
-    } else {
-      // Stamping mapping
-      NumericField(
-        title = stringResource(R.string.bg_label_animation_rows),
-        value = layer.animationRows.toFloat(),
-        limits = NumericLimits.standard(1f, 100f, 1f),
-        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setAnimationRows(it.toInt()).build())) }
-      )
-      NumericField(
-        title = stringResource(R.string.bg_label_animation_columns),
-        value = layer.animationColumns.toFloat(),
-        limits = NumericLimits.standard(1f, 100f, 1f),
-        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setAnimationColumns(it.toInt()).build())) }
-      )
-      NumericField(
-        title = stringResource(R.string.bg_label_animation_frames),
-        value = layer.animationFrames.toFloat(),
-        limits = NumericLimits.standard(1f, 100f, 1f),
-        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setAnimationFrames(it.toInt()).build())) }
-      )
-      NumericField(
-        title = stringResource(R.string.bg_label_animation_duration_ms),
-        value = layer.animationDurationSeconds,
-        limits = NumericLimits(1f, 10000f, 1f, "ms", unitScale = 1000f),
-        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setAnimationDurationSeconds(it).build())) }
-      )
     }
 
     InspectorSectionHeader(stringResource(R.string.bg_section_positioning), stringResource(R.string.bg_section_positioning_sub))

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TextureLayerNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/TextureLayerNodeFields.kt
@@ -1,0 +1,322 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.ink.brush.ExperimentalInkCustomBrushApi::class, androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
+import com.example.cahier.R
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.ink.rendering.android.canvas.CanvasStrokeRenderer
+import com.example.cahier.developer.brushdesigner.ui.EnumDropdown
+import com.example.cahier.developer.brushdesigner.ui.NumericField
+import com.example.cahier.developer.brushdesigner.ui.NumericLimits
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import com.example.cahier.developer.brushgraph.ui.FieldWithTooltip
+import com.example.cahier.developer.brushgraph.ui.getTooltip
+import com.example.cahier.developer.brushgraph.ui.TextureLayerPreviewWidget
+import com.example.cahier.developer.brushgraph.ui.TextureWrapPreviewWidget
+import com.example.cahier.developer.brushgraph.ui.BlendModePreviewWidget
+import ink.proto.BrushPaint as ProtoBrushPaint
+
+@Composable
+fun TextureLayerNodeFields(
+  layer: ProtoBrushPaint.TextureLayer,
+  allTextureIds: Set<String>,
+  onLoadTexture: () -> Unit,
+  onUpdate: (NodeData.TextureLayer) -> Unit,
+  strokeRenderer: CanvasStrokeRenderer,
+  modifier: Modifier = Modifier
+) {
+  Column(modifier = modifier) {
+    Row(verticalAlignment = Alignment.Bottom, modifier = Modifier.padding(bottom = 8.dp)) {
+      EnumDropdown(
+        label = stringResource(R.string.bg_texture_id),
+        currentValue = layer.clientTextureId,
+        values = allTextureIds.toList(),
+        modifier = Modifier.weight(1f),
+        displayName = { it },
+        onSelected = { id ->
+          onUpdate(NodeData.TextureLayer(layer.toBuilder().setClientTextureId(id).build()))
+        }
+      )
+      IconButton(onClick = onLoadTexture, enabled = true) {
+        Icon(Icons.Default.Upload, contentDescription = stringResource(R.string.bg_cd_upload_texture))
+      }
+    }
+
+    TextureLayerPreviewWidget(textureLayer = layer, renderer = strokeRenderer)
+
+    InspectorSectionHeader(stringResource(R.string.bg_section_mapping), stringResource(R.string.bg_section_mapping_sub))
+
+    FieldWithTooltip(
+      tooltipTitle = stringResource(R.string.bg_label_mapping_mode_with_value, stringResource(layer.mapping.displayStringRId())),
+      tooltipText = stringResource(layer.mapping.getTooltip()),
+      modifier = Modifier.padding(vertical = 4.dp)
+    ) {
+      EnumDropdown(
+        label = stringResource(R.string.bg_mapping_mode),
+        currentValue = layer.mapping,
+        values = listOf(
+          ProtoBrushPaint.TextureLayer.Mapping.MAPPING_TILING,
+          ProtoBrushPaint.TextureLayer.Mapping.MAPPING_STAMPING,
+        ),
+        displayName = { stringResource(it.displayStringRId()) },
+        onSelected = { mapping ->
+          onUpdate(NodeData.TextureLayer(layer.toBuilder().setMapping(mapping).build()))
+        }
+      )
+    }
+
+    if (layer.mapping == ProtoBrushPaint.TextureLayer.Mapping.MAPPING_TILING) {
+      NumericField(
+        title = stringResource(R.string.bg_label_size_x),
+        value = layer.sizeX,
+        limits = NumericLimits.standard(0.1f, 1000f, 0.1f),
+        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setSizeX(it).build())) }
+      )
+      NumericField(
+        title = stringResource(R.string.bg_label_size_y),
+        value = layer.sizeY,
+        limits = NumericLimits.standard(0.1f, 1000f, 0.1f),
+        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setSizeY(it).build())) }
+      )
+      FieldWithTooltip(
+        tooltipTitle = stringResource(R.string.bg_label_size_unit_with_value, stringResource(layer.sizeUnit.displayStringRId())),
+        tooltipText = stringResource(layer.sizeUnit.getTooltip()),
+        modifier = Modifier.padding(vertical = 4.dp)
+      ) {
+        EnumDropdown(
+          label = stringResource(R.string.bg_size_unit),
+          currentValue = layer.sizeUnit,
+          values = listOf(
+            ProtoBrushPaint.TextureLayer.SizeUnit.SIZE_UNIT_BRUSH_SIZE,
+            ProtoBrushPaint.TextureLayer.SizeUnit.SIZE_UNIT_STROKE_COORDINATES,
+          ),
+          displayName = { stringResource(it.displayStringRId()) },
+          onSelected = { unit ->
+            onUpdate(NodeData.TextureLayer(layer.toBuilder().setSizeUnit(unit).build()))
+          }
+        )
+      }
+    } else {
+      // Stamping mapping
+      NumericField(
+        title = stringResource(R.string.bg_label_animation_rows),
+        value = layer.animationRows.toFloat(),
+        limits = NumericLimits.standard(1f, 100f, 1f),
+        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setAnimationRows(it.toInt()).build())) }
+      )
+      NumericField(
+        title = stringResource(R.string.bg_label_animation_columns),
+        value = layer.animationColumns.toFloat(),
+        limits = NumericLimits.standard(1f, 100f, 1f),
+        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setAnimationColumns(it.toInt()).build())) }
+      )
+      NumericField(
+        title = stringResource(R.string.bg_label_animation_frames),
+        value = layer.animationFrames.toFloat(),
+        limits = NumericLimits.standard(1f, 100f, 1f),
+        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setAnimationFrames(it.toInt()).build())) }
+      )
+      NumericField(
+        title = stringResource(R.string.bg_label_animation_duration_ms),
+        value = layer.animationDurationSeconds,
+        limits = NumericLimits(1f, 10000f, 1f, "ms", unitScale = 1000f),
+        onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setAnimationDurationSeconds(it).build())) }
+      )
+    }
+
+    InspectorSectionHeader(stringResource(R.string.bg_section_positioning), stringResource(R.string.bg_section_positioning_sub))
+
+    FieldWithTooltip(
+      tooltipTitle = stringResource(R.string.bg_label_origin_with_value, stringResource(layer.origin.displayStringRId())),
+      tooltipText = stringResource(layer.origin.getTooltip()),
+      modifier = Modifier.padding(vertical = 4.dp)
+    ) {
+      EnumDropdown(
+        label = stringResource(R.string.bg_origin),
+        currentValue = layer.origin,
+        values = listOf(
+          ProtoBrushPaint.TextureLayer.Origin.ORIGIN_STROKE_SPACE_ORIGIN,
+          ProtoBrushPaint.TextureLayer.Origin.ORIGIN_FIRST_STROKE_INPUT,
+          ProtoBrushPaint.TextureLayer.Origin.ORIGIN_LAST_STROKE_INPUT,
+        ),
+        displayName = { stringResource(it.displayStringRId()) },
+        onSelected = { origin ->
+          onUpdate(NodeData.TextureLayer(layer.toBuilder().setOrigin(origin).build()))
+        }
+      )
+    }
+    NumericField(
+      title = stringResource(R.string.bg_label_offset_x),
+      value = layer.offsetX,
+      limits = NumericLimits.standard(-1f, 1f, 0.01f),
+      onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setOffsetX(it).build())) }
+    )
+    NumericField(
+      title = stringResource(R.string.bg_label_offset_y),
+      value = layer.offsetY,
+      limits = NumericLimits.standard(-1f, 1f, 0.01f),
+      onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setOffsetY(it).build())) }
+    )
+    NumericField(
+      title = stringResource(R.string.bg_label_rotation_degrees),
+      value = layer.rotationInRadians,
+      limits = NumericLimits.radiansShownAsDegrees(0f, 360f),
+      onValueChanged = { onUpdate(NodeData.TextureLayer(layer.toBuilder().setRotationInRadians(it).build())) }
+    )
+
+    InspectorSectionHeader(stringResource(R.string.bg_section_wrapping), stringResource(R.string.bg_section_wrapping_sub))
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      Column(modifier = Modifier.weight(1f)) {
+        FieldWithTooltip(
+          tooltipTitle = stringResource(R.string.bg_label_wrap_x_with_value, stringResource(layer.wrapX.displayStringRId())),
+          tooltipText = stringResource(layer.wrapX.getTooltip()),
+          modifier = Modifier.padding(vertical = 4.dp)
+        ) {
+          EnumDropdown(
+            label = stringResource(R.string.bg_wrap_x),
+            currentValue = layer.wrapX,
+            values = listOf(
+              ProtoBrushPaint.TextureLayer.Wrap.WRAP_REPEAT,
+              ProtoBrushPaint.TextureLayer.Wrap.WRAP_MIRROR,
+              ProtoBrushPaint.TextureLayer.Wrap.WRAP_CLAMP,
+            ),
+            displayName = { stringResource(it.displayStringRId()) },
+            onSelected = { wrap ->
+              onUpdate(NodeData.TextureLayer(layer.toBuilder().setWrapX(wrap).build()))
+            }
+          )
+        }
+        FieldWithTooltip(
+          tooltipTitle = stringResource(R.string.bg_label_wrap_y_with_value, stringResource(layer.wrapY.displayStringRId())),
+          tooltipText = stringResource(layer.wrapY.getTooltip()),
+          modifier = Modifier.padding(vertical = 4.dp)
+        ) {
+          EnumDropdown(
+            label = stringResource(R.string.bg_wrap_y),
+            currentValue = layer.wrapY,
+            values = listOf(
+              ProtoBrushPaint.TextureLayer.Wrap.WRAP_REPEAT,
+              ProtoBrushPaint.TextureLayer.Wrap.WRAP_MIRROR,
+              ProtoBrushPaint.TextureLayer.Wrap.WRAP_CLAMP,
+            ),
+            displayName = { stringResource(it.displayStringRId()) },
+            onSelected = { wrap ->
+              onUpdate(NodeData.TextureLayer(layer.toBuilder().setWrapY(wrap).build()))
+            }
+          )
+        }
+      }
+      Box(modifier = Modifier.padding(start = 8.dp)) {
+        TextureWrapPreviewWidget(
+          wrapX = layer.wrapX,
+          wrapY = layer.wrapY,
+          renderer = strokeRenderer,
+          clientTextureId = layer.clientTextureId
+        )
+      }
+    }
+
+    InspectorSectionHeader(stringResource(R.string.bg_section_blending), stringResource(R.string.bg_section_blending_sub))
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      Box(modifier = Modifier.weight(1f)) {
+        FieldWithTooltip(
+          tooltipTitle = stringResource(R.string.bg_label_blend_mode_with_value, stringResource(layer.blendMode.displayStringRId())),
+          tooltipText = stringResource(layer.blendMode.getTooltip()),
+          modifier = Modifier.padding(vertical = 4.dp)
+        ) {
+          EnumDropdown(
+            label = stringResource(R.string.bg_blend_mode),
+            currentValue = layer.blendMode,
+            values = listOf(
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_SRC_OVER,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_SRC,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_MODULATE,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_DST_OVER,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_DST,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_SRC_IN,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_DST_IN,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_SRC_OUT,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_DST_OUT,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_SRC_ATOP,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_DST_ATOP,
+              ProtoBrushPaint.TextureLayer.BlendMode.BLEND_MODE_XOR,
+            ),
+            displayName = { stringResource(it.displayStringRId()) },
+            onSelected = { mode ->
+              onUpdate(NodeData.TextureLayer(layer.toBuilder().setBlendMode(mode).build()))
+            }
+          )
+        }
+      }
+      Box(modifier = Modifier.padding(start = 8.dp)) {
+        BlendModePreviewWidget(
+          blendMode = layer.blendMode,
+          renderer = strokeRenderer,
+          clientTextureId = layer.clientTextureId
+        )
+      }
+    }
+
+  }
+}
+
+@Composable
+private fun InspectorSectionHeader(title: String, subtitle: String, modifier: Modifier = Modifier) {
+  Column(modifier = modifier.padding(top = 16.dp, bottom = 4.dp)) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.titleMedium,
+      color = MaterialTheme.colorScheme.primary,
+      fontWeight = FontWeight.Bold
+    )
+    Text(
+      text = subtitle,
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.secondary
+    )
+    HorizontalDivider(modifier = Modifier.padding(top = 4.dp), color = MaterialTheme.colorScheme.outlineVariant)
+  }
+}

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ToolTypeFilterNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ToolTypeFilterNodeFields.kt
@@ -17,6 +17,7 @@
 
 package com.example.cahier.developer.brushgraph.ui.fields
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
@@ -38,29 +39,31 @@ fun ToolTypeFilterNodeFields(
   onUpdate: (NodeData) -> Unit,
   modifier: Modifier = Modifier
 ) {
-  Text(stringResource(R.string.bg_enabled_tool_types), style = MaterialTheme.typography.bodySmall)
-  ALL_TOOL_TYPES.forEach { toolType ->
-    Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
-      val bitIndex = toolTypeBitIndex(toolType)
-      Checkbox(
-        checked = (filterNode.enabledToolTypes and (1 shl bitIndex)) != 0,
-        onCheckedChange = { checked ->
-          val newMask =
-            if (checked) {
-              filterNode.enabledToolTypes or (1 shl bitIndex)
-            } else {
-              filterNode.enabledToolTypes and (1 shl bitIndex).inv()
-            }
-          onUpdate(
-            NodeData.Behavior(
-              behaviorNode.toBuilder()
-                .setToolTypeFilterNode(filterNode.toBuilder().setEnabledToolTypes(newMask).build())
-                .build()
+  Column(modifier = modifier) {
+    Text(stringResource(R.string.bg_enabled_tool_types), style = MaterialTheme.typography.bodySmall)
+    ALL_TOOL_TYPES.forEach { toolType ->
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        val bitIndex = toolTypeBitIndex(toolType)
+        Checkbox(
+          checked = (filterNode.enabledToolTypes and (1 shl bitIndex)) != 0,
+          onCheckedChange = { checked ->
+            val newMask =
+              if (checked) {
+                filterNode.enabledToolTypes or (1 shl bitIndex)
+              } else {
+                filterNode.enabledToolTypes and (1 shl bitIndex).inv()
+              }
+            onUpdate(
+              NodeData.Behavior(
+                behaviorNode.toBuilder()
+                  .setToolTypeFilterNode(filterNode.toBuilder().setEnabledToolTypes(newMask).build())
+                  .build()
+              )
             )
-          )
-        }
-      )
-      Text(stringResource(toolType.displayStringRId()))
+          }
+        )
+        Text(stringResource(toolType.displayStringRId()))
+      }
     }
   }
 }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ToolTypeFilterNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ToolTypeFilterNodeFields.kt
@@ -1,0 +1,75 @@
+/*
+ *  * Copyright 2026 Google LLC. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ */
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.cahier.developer.brushgraph.ui.fields
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.displayStringRId
+import androidx.ink.brush.InputToolType
+import com.example.cahier.R
+import ink.proto.BrushBehavior as ProtoBrushBehavior
+
+@Composable
+fun ToolTypeFilterNodeFields(
+  filterNode: ProtoBrushBehavior.ToolTypeFilterNode,
+  behaviorNode: ProtoBrushBehavior.Node,
+  onUpdate: (NodeData) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Text(stringResource(R.string.bg_enabled_tool_types), style = MaterialTheme.typography.bodySmall)
+  ALL_TOOL_TYPES.forEach { toolType ->
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
+      val bitIndex = toolTypeBitIndex(toolType)
+      Checkbox(
+        checked = (filterNode.enabledToolTypes and (1 shl bitIndex)) != 0,
+        onCheckedChange = { checked ->
+          val newMask =
+            if (checked) {
+              filterNode.enabledToolTypes or (1 shl bitIndex)
+            } else {
+              filterNode.enabledToolTypes and (1 shl bitIndex).inv()
+            }
+          onUpdate(
+            NodeData.Behavior(
+              behaviorNode.toBuilder()
+                .setToolTypeFilterNode(filterNode.toBuilder().setEnabledToolTypes(newMask).build())
+                .build()
+            )
+          )
+        }
+      )
+      Text(stringResource(toolType.displayStringRId()))
+    }
+  }
+}
+
+private fun toolTypeBitIndex(toolType: InputToolType): Int =
+  when (toolType) {
+    InputToolType.UNKNOWN -> 0
+    InputToolType.MOUSE -> 1
+    InputToolType.TOUCH -> 2
+    InputToolType.STYLUS -> 3
+    else -> 0
+  }


### PR DESCRIPTION
## Description
This is the fifth PR in the Brush Graph stack. It completes the node field editors by adding the more complex ones.
## Details
- Complex UI models for viewing and editing the fields of the remaining node types.
- Top-level NodeFields
## Dependencies
- Target: `brush-graph/4-nodes`