### PR TITLE
Enable emoji highlighter entry point in brush graph

### DIFF
--- a/app/src/main/java/com/example/cahier/developer/brushdesigner/ui/BrushDesignerTopBar.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushdesigner/ui/BrushDesignerTopBar.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -146,7 +148,10 @@ private fun BrushLibraryMenu(
             R.string.marker to StockBrushes.marker(),
             R.string.pressure_pen to StockBrushes.pressurePen(),
             R.string.dashed_line to StockBrushes.dashedLine(),
-            R.string.emoji_highlighter to StockBrushes.emojiHighlighter("emoji-heart", showMiniEmojiTrail = true),
+            R.string.emoji_highlighter to StockBrushes.emojiHighlighter(
+                "emoji-heart",
+                showMiniEmojiTrail = true
+            ),
         )
     }
 
@@ -166,42 +171,50 @@ private fun BrushLibraryMenu(
                 onClick = {},
                 enabled = false
             )
-            stockBrushes.filter { it.first != R.string.emoji_highlighter }.forEach { (nameResId, brushFamily) ->
-                DropdownMenuItem(
-                    text = { Text(stringResource(nameResId)) },
-                    onClick = {
-                        onLoadBrush(brushFamily)
-                        expanded = false
-                    }
-                )
-            }
-            
+            stockBrushes.filter { it.first != R.string.emoji_highlighter }
+                .forEach { (nameResId, brushFamily) ->
+                    DropdownMenuItem(
+                        text = { Text(stringResource(nameResId)) },
+                        onClick = {
+                            onLoadBrush(brushFamily)
+                            expanded = false
+                        }
+                    )
+                }
+
             var showEmojiSubMenu by remember { mutableStateOf(false) }
             var itemWidth by remember { mutableStateOf(0) }
             var itemHeight by remember { mutableStateOf(0) }
             val density = LocalDensity.current
-            
-            Box(modifier = Modifier.onSizeChanged { 
+
+            Box(modifier = Modifier.onSizeChanged {
                 itemWidth = it.width
                 itemHeight = it.height
             }) {
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.emoji_highlighter)) },
                     trailingIcon = {
-                        Text(text = if (showEmojiSubMenu) "▶" else "▼")
+                        Icon(Icons.Default.ChevronRight, contentDescription = null)
                     },
                     onClick = { showEmojiSubMenu = true }
                 )
                 DropdownMenu(
                     expanded = showEmojiSubMenu,
                     onDismissRequest = { showEmojiSubMenu = false },
-                    offset = DpOffset(x = density.run { itemWidth.toDp() }, y = density.run { -itemHeight.toDp() }),
+                    offset = DpOffset(
+                        x = density.run { itemWidth.toDp() },
+                        y = density.run { -itemHeight.toDp() }),
                     properties = PopupProperties(focusable = true)
                 ) {
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.emoji_heart)) },
                         onClick = {
-                            onLoadBrush(StockBrushes.emojiHighlighter("emoji-heart", showMiniEmojiTrail = true))
+                            onLoadBrush(
+                                StockBrushes.emojiHighlighter(
+                                    "emoji-heart",
+                                    showMiniEmojiTrail = true
+                                )
+                            )
                             showEmojiSubMenu = false
                             expanded = false
                         }
@@ -209,7 +222,12 @@ private fun BrushLibraryMenu(
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.emoji_star)) },
                         onClick = {
-                            onLoadBrush(StockBrushes.emojiHighlighter("emoji-star", showMiniEmojiTrail = true))
+                            onLoadBrush(
+                                StockBrushes.emojiHighlighter(
+                                    "emoji-star",
+                                    showMiniEmojiTrail = true
+                                )
+                            )
                             showEmojiSubMenu = false
                             expanded = false
                         }
@@ -217,7 +235,12 @@ private fun BrushLibraryMenu(
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.emoji_poop)) },
                         onClick = {
-                            onLoadBrush(StockBrushes.emojiHighlighter("emoji-poop", showMiniEmojiTrail = true))
+                            onLoadBrush(
+                                StockBrushes.emojiHighlighter(
+                                    "emoji-poop",
+                                    showMiniEmojiTrail = true
+                                )
+                            )
                             showEmojiSubMenu = false
                             expanded = false
                         }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/BrushGraphMenus.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/BrushGraphMenus.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
@@ -53,6 +54,7 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -69,6 +71,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.zIndex
 import androidx.ink.brush.BrushFamily
 import androidx.ink.brush.StockBrushes
@@ -129,8 +132,15 @@ fun MoreOptionsMenu(
         Box {
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.bg_templates)) },
-                onClick = { onShowTemplatesMenuChange(true) },
-                trailingIcon = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+                onClick = {
+                    onShowTemplatesMenuChange(true)
+                },
+                trailingIcon = {
+                    Icon(
+                        if (showTemplatesMenu) Icons.Default.ChevronRight else Icons.Default.ExpandMore,
+                        contentDescription = null
+                    )
+                },
                 modifier = Modifier.onSizeChanged { itemSize = it }
             )
             DropdownMenu(
@@ -144,7 +154,7 @@ fun MoreOptionsMenu(
                     R.string.bg_pressure_pen to StockBrushes.pressurePen(),
                     R.string.marker to StockBrushes.marker(),
                     R.string.highlighter to StockBrushes.highlighter(),
-                    R.string.dashed_line to StockBrushes.dashedLine()
+                    R.string.dashed_line to StockBrushes.dashedLine(),
                 ).forEach { (title, brush) ->
                     DropdownMenuItem(
                         text = { Text(stringResource(title)) },
@@ -153,6 +163,54 @@ fun MoreOptionsMenu(
                             onShowTemplatesMenuChange(false)
                         }
                     )
+                }
+                var showEmojiSubMenu by remember { mutableStateOf(false) }
+                var itemWidth by remember { mutableIntStateOf(0) }
+                var itemHeight by remember { mutableIntStateOf(0) }
+                val density = LocalDensity.current
+
+                Box(modifier = Modifier.onSizeChanged {
+                    itemWidth = it.width
+                    itemHeight = it.height
+                }) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.emoji_highlighter)) },
+                        trailingIcon = {
+                            Icon(
+                                if (showEmojiSubMenu) Icons.Default.ChevronRight else Icons.Default.ExpandMore,
+                                contentDescription = null
+                            )
+                        },
+                        onClick = { showEmojiSubMenu = true }
+                    )
+                    DropdownMenu(
+                        expanded = showEmojiSubMenu,
+                        onDismissRequest = { showEmojiSubMenu = false },
+                        offset = DpOffset(
+                            x = density.run { itemWidth.toDp() },
+                            y = density.run { -itemHeight.toDp() }),
+                        properties = PopupProperties(focusable = true)
+                    ) {
+                        listOf(
+                            R.string.emoji_heart to "emoji-heart",
+                            R.string.emoji_star to "emoji-star",
+                            R.string.emoji_poop to "emoji-poop",
+                        ).forEach { (title, textureId) ->
+                            DropdownMenuItem(
+                                text = { Text(stringResource(title)) },
+                                onClick = {
+                                    onTemplateSelect(
+                                        StockBrushes.emojiHighlighter(
+                                            textureId,
+                                            showMiniEmojiTrail = true
+                                        )
+                                    )
+                                    onShowTemplatesMenuChange(false)
+                                    showEmojiSubMenu = false
+                                }
+                            )
+                        }
+                    }
                 }
 
                 if (customBrushes.isNotEmpty()) {

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/BrushGraphMenus.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/BrushGraphMenus.kt
@@ -36,7 +36,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
@@ -137,7 +136,7 @@ fun MoreOptionsMenu(
                 },
                 trailingIcon = {
                     Icon(
-                        if (showTemplatesMenu) Icons.Default.ChevronRight else Icons.Default.ExpandMore,
+                        Icons.Default.ChevronRight,
                         contentDescription = null
                     )
                 },
@@ -177,7 +176,7 @@ fun MoreOptionsMenu(
                         text = { Text(stringResource(R.string.emoji_highlighter)) },
                         trailingIcon = {
                             Icon(
-                                if (showEmojiSubMenu) Icons.Default.ChevronRight else Icons.Default.ExpandMore,
+                                Icons.Default.ChevronRight,
                                 contentDescription = null
                             )
                         },

--- a/app/src/main/java/com/example/cahier/features/drawing/CustomBrushes.kt
+++ b/app/src/main/java/com/example/cahier/features/drawing/CustomBrushes.kt
@@ -51,14 +51,14 @@ object CustomBrushes {
             context.getString(R.string.graffiti) to (R.raw.graffiti to R.drawable.format_paint_24px),
             context.getString(R.string.groovy) to (R.raw.groovy to R.drawable.bubble_chart_24px),
             context.getString(R.string.holiday_lights) to (R.raw.holiday_lights to R.drawable.lightbulb_24px),
+            context.getString(R.string.jelly_wobble) to (R.raw.jelly_wobble to R.drawable.airwave_24px),
             context.getString(R.string.lace) to (R.raw.lace to R.drawable.styler_24px),
             context.getString(R.string.music) to (R.raw.music to R.drawable.music_note_24px),
+            context.getString(R.string.pressure_wave) to (R.raw.pressure_wave to R.drawable.vital_signs_24px),
+            context.getString(R.string.shading_pencil) to (R.raw.shading_pencil to R.drawable.stylus_pencil_24px),
             context.getString(R.string.shadow) to (R.raw.shadow to R.drawable.blur_on_24px),
             context.getString(R.string.twisted_yarn) to (R.raw.twisted_yarn to R.drawable.line_weight_24px),
             context.getString(R.string.wet_paint) to (R.raw.wet_paint to R.drawable.water_drop_24px),
-            context.getString(R.string.jelly_wobble) to (R.raw.jelly_wobble to R.drawable.airwave_24px),
-            context.getString(R.string.pressure_wave) to (R.raw.pressure_wave to R.drawable.vital_signs_24px),
-            context.getString(R.string.shading_pencil) to (R.raw.shading_pencil to R.drawable.stylus_pencil_24px),
         )
 
         val loadedBrushes = brushFiles.mapNotNull { (name, pair) ->

--- a/app/src/main/java/com/example/cahier/features/drawing/DrawingToolbox.kt
+++ b/app/src/main/java/com/example/cahier/features/drawing/DrawingToolbox.kt
@@ -29,6 +29,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -75,7 +77,7 @@ fun DrawingToolbox(
     onEditActiveBrush: () -> Unit,
     isVertical: Boolean,
     onColorPickerClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Surface(
         modifier = modifier,
@@ -115,7 +117,7 @@ internal fun ToolboxBrushControls(
     drawingCanvasViewModel: DrawingCanvasViewModel,
     isVertical: Boolean,
     onColorPickerClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val brushesMenuExpanded = rememberSaveable { mutableStateOf(false) }
     val sizeMenuExpanded = rememberSaveable { mutableStateOf(false) }
@@ -155,7 +157,7 @@ private fun ToolBoxContent(
     customBrushes: List<CustomBrush>,
     onColorPickerClick: () -> Unit,
     isEraserMode: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Box(
         modifier = modifier
@@ -226,7 +228,7 @@ internal fun ToolboxHistoryControls(
     drawingCanvasViewModel: DrawingCanvasViewModel,
     onClear: () -> Unit,
     isVertical: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     if (isVertical) {
         Column(modifier = modifier) {
@@ -317,7 +319,7 @@ internal fun ToolboxNoteActions(
     onExit: () -> Unit,
     onEditActiveBrush: () -> Unit,
     isVertical: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     if (isVertical) {
         Column(modifier = modifier) {
@@ -345,7 +347,7 @@ private fun ToolboxNoteActionsContent(
     drawingCanvasViewModel: DrawingCanvasViewModel,
     imagePickerLauncher: ActivityResultLauncher<PickVisualMediaRequest>,
     onExit: () -> Unit,
-    onEditActiveBrush: () -> Unit
+    onEditActiveBrush: () -> Unit,
 ) {
     val uiState by drawingCanvasViewModel.uiState.collectAsStateWithLifecycle()
     var optionsMenuExpanded by rememberSaveable { mutableStateOf(false) }
@@ -433,7 +435,7 @@ fun SizeDropdownMenu(
     expanded: Boolean,
     onDismissRequest: () -> Unit,
     onSizeChange: (Float) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val sizes = listOf(5f, 10f, 15f, 20f, 25f)
     DropdownMenu(
@@ -457,10 +459,10 @@ fun BrushesDropdownMenu(
     onDismissRequest: () -> Unit,
     onBrushChange: (BrushFamily) -> Unit,
     customBrushes: List<CustomBrush>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var showEmojiSubMenu by remember { mutableStateOf(false) }
-    
+
     DropdownMenu(
         expanded = expanded,
         onDismissRequest = {
@@ -510,33 +512,35 @@ fun BrushesDropdownMenu(
             },
             onClick = { onBrushChange(StockBrushes.dashedLine()) }
         )
-            var itemWidth by remember { mutableStateOf(0) }
-            var itemHeight by remember { mutableStateOf(0) }
-            val density = LocalDensity.current
-            
-            Box(modifier = Modifier.onSizeChanged { 
-                itemWidth = it.width
-                itemHeight = it.height
-            }) {
-                DropdownMenuItem(
-                    text = { Text(text = stringResource(R.string.emoji_highlighter)) },
-                    leadingIcon = {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_emoji_highlighter),
-                            contentDescription = stringResource(R.string.emoji_highlighter)
-                        )
-                    },
-                    trailingIcon = {
-                        Text(text = if (showEmojiSubMenu) "▶" else "▼")
-                    },
-                    onClick = { showEmojiSubMenu = true }
-                )
-                DropdownMenu(
-                    expanded = showEmojiSubMenu,
-                    onDismissRequest = { showEmojiSubMenu = false },
-                    offset = DpOffset(x = density.run { itemWidth.toDp() }, y = density.run { -itemHeight.toDp() }),
-                    properties = PopupProperties(focusable = true)
-                ) {
+        var itemWidth by remember { mutableStateOf(0) }
+        var itemHeight by remember { mutableStateOf(0) }
+        val density = LocalDensity.current
+
+        Box(modifier = Modifier.onSizeChanged {
+            itemWidth = it.width
+            itemHeight = it.height
+        }) {
+            DropdownMenuItem(
+                text = { Text(text = stringResource(R.string.emoji_highlighter)) },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_emoji_highlighter),
+                        contentDescription = stringResource(R.string.emoji_highlighter)
+                    )
+                },
+                trailingIcon = {
+                    Icon(Icons.Default.ChevronRight, contentDescription = null)
+                },
+                onClick = { showEmojiSubMenu = true }
+            )
+            DropdownMenu(
+                expanded = showEmojiSubMenu,
+                onDismissRequest = { showEmojiSubMenu = false },
+                offset = DpOffset(
+                    x = density.run { itemWidth.toDp() },
+                    y = density.run { -itemHeight.toDp() }),
+                properties = PopupProperties(focusable = true)
+            ) {
                 DropdownMenuItem(
                     text = { Text(text = stringResource(R.string.emoji_heart)) },
                     leadingIcon = {
@@ -546,7 +550,12 @@ fun BrushesDropdownMenu(
                         )
                     },
                     onClick = {
-                        onBrushChange(StockBrushes.emojiHighlighter("emoji-heart", showMiniEmojiTrail = true))
+                        onBrushChange(
+                            StockBrushes.emojiHighlighter(
+                                "emoji-heart",
+                                showMiniEmojiTrail = true
+                            )
+                        )
                         showEmojiSubMenu = false
                         onDismissRequest()
                     }
@@ -560,7 +569,12 @@ fun BrushesDropdownMenu(
                         )
                     },
                     onClick = {
-                        onBrushChange(StockBrushes.emojiHighlighter("emoji-star", showMiniEmojiTrail = true))
+                        onBrushChange(
+                            StockBrushes.emojiHighlighter(
+                                "emoji-star",
+                                showMiniEmojiTrail = true
+                            )
+                        )
                         showEmojiSubMenu = false
                         onDismissRequest()
                     }
@@ -574,7 +588,12 @@ fun BrushesDropdownMenu(
                         )
                     },
                     onClick = {
-                        onBrushChange(StockBrushes.emojiHighlighter("emoji-poop", showMiniEmojiTrail = true))
+                        onBrushChange(
+                            StockBrushes.emojiHighlighter(
+                                "emoji-poop",
+                                showMiniEmojiTrail = true
+                            )
+                        )
                         showEmojiSubMenu = false
                         onDismissRequest()
                     }


### PR DESCRIPTION
Very similar to the code in brush designer's top bar which does similar handling. Uses chevron style icons instead of the character for the "arrow" indicating the submenu, in keeping with the aesthetics already present in brush graph's template menu/material design.

Some formatting changes came along too on save. Should be mostly whitespace there.

Also alphabetize the custom brushes -- I messed this up on my prior PR and put them in out of order. This fixes them back to being in order.