### PR TITLE
Converge language around brush family files

### DIFF
--- a/app/src/main/java/com/example/cahier/developer/brushdesigner/ui/BrushDesignerScreen.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushdesigner/ui/BrushDesignerScreen.kt
@@ -153,7 +153,16 @@ fun BrushDesignerScreen(
                 onImport = {
                     importLauncher.launch(arrayOf("application/octet-stream", "*/*"))
                 },
-                onExport = { exportLauncher.launch("custom_${System.currentTimeMillis()}.brushfamily") }
+                onExport = {
+                    exportLauncher.launch(
+                        "custom_${
+                            android.text.format.DateFormat.format(
+                                "yyyyMMdd_HHmmss",
+                                System.currentTimeMillis()
+                            )
+                        }.brushfamily"
+                    )
+                }
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/example/cahier/developer/brushdesigner/ui/BrushDesignerScreen.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushdesigner/ui/BrushDesignerScreen.kt
@@ -153,7 +153,7 @@ fun BrushDesignerScreen(
                 onImport = {
                     importLauncher.launch(arrayOf("application/octet-stream", "*/*"))
                 },
-                onExport = { exportLauncher.launch("custom_brush.brush") }
+                onExport = { exportLauncher.launch("custom_${System.currentTimeMillis()}.brushfamily") }
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/BrushGraphScreen.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/BrushGraphScreen.kt
@@ -564,7 +564,14 @@ fun BrushGraphScreen(
                         GraphActionMenu(
                             onClose = onNavigateUp,
                             onExport = {
-                                brushExportLauncher.launch("custom_${System.currentTimeMillis()}.brushfamily")
+                                brushExportLauncher.launch(
+                                    "custom_${
+                                        android.text.format.DateFormat.format(
+                                            "yyyyMMdd_HHmmss",
+                                            System.currentTimeMillis()
+                                        )
+                                    }.brushfamily"
+                                )
                             },
                             onLoadBrushFile = { brushFilePickerLauncher.launch(arrayOf("*/*")) },
                             onSaveToPalette = {

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/BrushGraphScreen.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/BrushGraphScreen.kt
@@ -564,7 +564,7 @@ fun BrushGraphScreen(
                         GraphActionMenu(
                             onClose = onNavigateUp,
                             onExport = {
-                                brushExportLauncher.launch("brush_${System.currentTimeMillis()}.brushfamily")
+                                brushExportLauncher.launch("custom_${System.currentTimeMillis()}.brushfamily")
                             },
                             onLoadBrushFile = { brushFilePickerLauncher.launch(arrayOf("*/*")) },
                             onSaveToPalette = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,7 +270,7 @@
     <string name="settings_developer_tools">Developer Tools</string>
     <string name="settings_developer_tools_description">Experimental features and debugging tools.</string>
     <string name="settings_brush_designer_title">Ink Brush Designer</string>
-    <string name="settings_brush_designer_description">Create, test, and export custom .brush files</string>
+    <string name="settings_brush_designer_description">Create, test, and export custom brush families.</string>
     <string name="settings_launch">Launch</string>
     <string name="settings_graph_ui">Graph UI</string>
     <string name="settings_graph_description">Visual, node-based brush designer</string>


### PR DESCRIPTION
Previously we used `.brush` in the tabbed editor, and `.brushfamily` in the graph editor, but we should  be consistent. Since Ink has the concept of both `Brush` and `BrushFamily`, it's more clear to use `.brushfamily`.

This PR also standardizes the name given by default when exporting to be `custom_${android.text.format.DateFormat.format("yyyyMMdd_HHmmss", System.currentTimeMillis())}`. I find it useful to have the timestamp when exporting lots of brush families, both to keep track of when I made the brushes, and to avoid overwriting a saved brush with the same name. Also, the previous prefix `brush_` has the same problems as `.brush`. `custom_` is not terribly descriptive, but I think looks better than either nothing, or `brushfamily_` (which is overly verbose and repetitive of the extension, IMO). I do also think it is helpful to have some element of the name that associates this brush with being designed in a brush designer tool, and `custom_` seems to be a good fit for that. 