### PR TITLE
Support new color functions for HSL shift

### DIFF
--- a/app/src/main/java/com/example/cahier/developer/brushgraph/data/DisplayUtils.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/data/DisplayUtils.kt
@@ -21,6 +21,7 @@ import com.example.cahier.developer.brushdesigner.ui.NumericLimits
 import ink.proto.BrushBehavior as ProtoBrushBehavior
 import ink.proto.BrushFamily as ProtoBrushFamily
 import ink.proto.BrushPaint as ProtoBrushPaint
+import ink.proto.ColorFunction as ProtoColorFunction
 import ink.proto.PredefinedEasingFunction as ProtoPredefinedEasingFunction
 import ink.proto.StepPosition as ProtoStepPosition
 
@@ -516,4 +517,19 @@ fun ProtoBrushFamily.InputModel.displayStringRId(): Int =
         hasSlidingWindowModel() -> R.string.bg_model_sliding_window
         hasPassthroughModel() -> R.string.bg_model_passthrough
         else -> R.string.bg_unknown_model
+    }
+
+fun ProtoColorFunction.displayStringRId(): Int =
+    if (this.hasOpacityMultiplier()) {
+        R.string.bg_target_opacity_multiplier
+    } else if (this.hasReplaceColor()) {
+        R.string.bg_replace_color
+    } else if (this.hasHueOffsetRadians()) {
+        R.string.bg_target_hue_offset
+    } else if (this.hasSaturationMultiplier()) {
+        R.string.bg_target_saturation_multiplier
+    } else if (this.hasLuminosityOffset()) {
+        R.string.bg_target_luminosity_offset
+    } else {
+        R.string.bg_node_unknown
     }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/data/GraphDataModel.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/data/GraphDataModel.kt
@@ -183,13 +183,7 @@ sealed interface NodeData {
         override fun title() = R.string.bg_color_function
 
         override fun subtitles() =
-            listOf(
-                if (function.hasOpacityMultiplier()) {
-                    DisplayText.Resource(R.string.bg_opacity_multiplier)
-                } else {
-                    DisplayText.Resource(R.string.bg_replace_color)
-                }
-            )
+            listOf(DisplayText.Resource(function.displayStringRId()))
     }
 
     /** Wraps a [ProtoBrushBehavior.Node] */

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/Tooltips.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/Tooltips.kt
@@ -220,7 +220,10 @@ fun getInputModelTooltip(resId: Int): Int = when (resId) {
 }
 
 fun getColorFunctionTooltip(resId: Int): Int = when (resId) {
-    R.string.bg_opacity_multiplier -> R.string.bg_tooltip_color_func_opacity
+    R.string.bg_target_opacity_multiplier -> R.string.bg_tooltip_color_func_opacity
     R.string.bg_replace_color -> R.string.bg_tooltip_color_func_replace
+    R.string.bg_target_luminosity_offset -> R.string.bg_tooltip_color_func_luminosity
+    R.string.bg_target_hue_offset -> R.string.bg_tooltip_color_func_hue
+    R.string.bg_target_saturation_multiplier -> R.string.bg_tooltip_color_func_saturation
     else -> R.string.bg_tooltip_color_func_default
 }

--- a/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ColorFunctionNodeFields.kt
+++ b/app/src/main/java/com/example/cahier/developer/brushgraph/ui/fields/ColorFunctionNodeFields.kt
@@ -39,6 +39,7 @@ import com.example.cahier.developer.brushdesigner.ui.EnumDropdown
 import com.example.cahier.developer.brushdesigner.ui.NumericField
 import com.example.cahier.developer.brushdesigner.ui.NumericLimits
 import com.example.cahier.developer.brushgraph.data.NodeData
+import com.example.cahier.developer.brushgraph.data.displayStringRId
 import com.example.cahier.developer.brushgraph.ui.FieldWithTooltip
 import com.example.cahier.developer.brushgraph.ui.getColorFunctionTooltip
 import ink.proto.Color as ProtoColor
@@ -46,18 +47,14 @@ import ink.proto.ColorFunction as ProtoColorFunction
 
 @Composable
 fun ColorFunctionNodeFields(
-  function: ProtoColorFunction,
-  onUpdate: (NodeData) -> Unit,
-  onChooseColor: (Color, (Color) -> Unit) -> Unit,
-  onDropdownEditComplete: () -> Unit,
-  onFieldEditComplete: () -> Unit,
-  modifier: Modifier = Modifier,
+    function: ProtoColorFunction,
+    onUpdate: (NodeData) -> Unit,
+    onChooseColor: (Color, (Color) -> Unit) -> Unit,
+    onDropdownEditComplete: () -> Unit,
+    onFieldEditComplete: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val currentTypeResId = if (function.hasOpacityMultiplier()) {
-        R.string.bg_opacity_multiplier
-    } else {
-        R.string.bg_replace_color
-    }
+    val currentTypeResId = function.displayStringRId()
 
     Column(modifier = modifier) {
         FieldWithTooltip(
@@ -70,28 +67,54 @@ fun ColorFunctionNodeFields(
             EnumDropdown(
                 label = stringResource(R.string.bg_function_type),
                 currentValue = currentTypeResId,
-                values = listOf(R.string.bg_opacity_multiplier, R.string.bg_replace_color),
+                values = listOf(
+                    R.string.bg_target_opacity_multiplier,
+                    R.string.bg_replace_color,
+                    R.string.bg_target_hue_offset,
+                    R.string.bg_target_saturation_multiplier,
+                    R.string.bg_target_luminosity_offset
+                ),
                 displayName = { stringResource(it) },
                 onSelected = { resId ->
                     if (resId != currentTypeResId) {
                         onUpdate(
-                            if (resId == R.string.bg_opacity_multiplier) {
-                                NodeData.ColorFunction(
-                                    ProtoColorFunction.newBuilder().setOpacityMultiplier(1f).build()
-                                )
-                            } else {
-                                NodeData.ColorFunction(
-                                    ProtoColorFunction.newBuilder()
-                                        .setReplaceColor(
-                                            ProtoColor.newBuilder()
-                                                .setRed(0f)
-                                                .setGreen(0f)
-                                                .setBlue(0f)
-                                                .setAlpha(1f)
-                                                .build()
-                                        )
-                                        .build()
-                                )
+                            when (resId) {
+                                R.string.bg_target_opacity_multiplier -> {
+                                    NodeData.ColorFunction(
+                                        ProtoColorFunction.newBuilder().setOpacityMultiplier(1f)
+                                            .build()
+                                    )
+                                }
+
+                                R.string.bg_replace_color -> {
+                                    NodeData.ColorFunction(
+                                        ProtoColorFunction.newBuilder().setReplaceColor(
+                                            ProtoColor.newBuilder().setRed(0f).setGreen(0f)
+                                                .setBlue(0f).setAlpha(1f).build()
+                                        ).build()
+                                    )
+                                }
+
+                                R.string.bg_target_hue_offset -> {
+                                    NodeData.ColorFunction(
+                                        ProtoColorFunction.newBuilder().setHueOffsetRadians(0f)
+                                            .build()
+                                    )
+                                }
+
+                                R.string.bg_target_saturation_multiplier -> {
+                                    NodeData.ColorFunction(
+                                        ProtoColorFunction.newBuilder().setSaturationMultiplier(1f)
+                                            .build()
+                                    )
+                                }
+
+                                else -> {  // bg_target_luminosity_offset
+                                    NodeData.ColorFunction(
+                                        ProtoColorFunction.newBuilder().setLuminosityOffset(0f)
+                                            .build()
+                                    )
+                                }
                             }
                         )
                     }
@@ -104,11 +127,53 @@ fun ColorFunctionNodeFields(
             NumericField(
                 title = stringResource(R.string.bg_label_opacity_multiplier),
                 value = function.opacityMultiplier,
-                limits = NumericLimits(0f, 2f, 0.01f),
+                limits = NumericLimits(0f, 2f, 0.01f, "x"),
                 onValueChanged = {
                     onUpdate(
                         NodeData.ColorFunction(
                             function.toBuilder().setOpacityMultiplier(it).build()
+                        )
+                    )
+                },
+                onValueChangeFinished = onFieldEditComplete
+            )
+        } else if (function.hasSaturationMultiplier()) {
+            NumericField(
+                title = stringResource(R.string.bg_label_saturation_multiplier),
+                value = function.saturationMultiplier,
+                limits = NumericLimits(0f, 2f, 0.01f, "x"),
+                onValueChanged = {
+                    onUpdate(
+                        NodeData.ColorFunction(
+                            function.toBuilder().setSaturationMultiplier(it).build()
+                        )
+                    )
+                },
+                onValueChangeFinished = onFieldEditComplete
+            )
+        } else if (function.hasHueOffsetRadians()) {
+            NumericField(
+                title = stringResource(R.string.bg_label_hue_offset),
+                value = function.hueOffsetRadians,
+                limits = NumericLimits.radiansShownAsDegrees(-360f, 360f),
+                onValueChanged = {
+                    onUpdate(
+                        NodeData.ColorFunction(
+                            function.toBuilder().setHueOffsetRadians(it).build()
+                        )
+                    )
+                },
+                onValueChangeFinished = onFieldEditComplete
+            )
+        } else if (function.hasLuminosityOffset()) {
+            NumericField(
+                title = stringResource(R.string.bg_label_luminosity_offset),
+                value = function.luminosityOffset,
+                limits = NumericLimits.floatShownAsPercent(-100f, 100f),
+                onValueChanged = {
+                    onUpdate(
+                        NodeData.ColorFunction(
+                            function.toBuilder().setLuminosityOffset(it).build()
                         )
                     )
                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,7 +497,6 @@
     <string name="bg_port_angle">Angle</string>
     <string name="bg_port_mag">Mag</string>
 
-    <string name="bg_opacity_multiplier">opacity multiplier</string>
     <string name="bg_replace_color">replace color</string>
 
     <string name="bg_tool_type_unknown">unknown</string>
@@ -661,6 +660,10 @@
     <string name="bg_label_out">Out</string>
     <string name="bg_label_step_count">Step Count</string>
     <string name="bg_label_opacity_multiplier">Opacity Multiplier</string>
+    <string name="bg_label_hue_offset">Hue Offset</string>
+    <string name="bg_label_saturation_multiplier">Saturation Multiplier</string>
+    <string name="bg_label_luminosity_offset">Luminosity Offset</string>
+
     <!-- Tooltips -->
     <!-- NodeData Tooltips -->
     <string name="bg_tooltip_node_tip">Defines the geometric shape and size of the brush tip. This shape acts as a cross-section that is repeated or extruded along the path to create the stroke mesh.</string>
@@ -837,8 +840,11 @@
     <string name="bg_tooltip_model_default">Selects the model used to smooth raw hardware inputs.</string>
 
     <!-- ColorFunc Tooltips -->
-    <string name="bg_tooltip_color_func_opacity">Multiplies the opacity of the stroke by a calculated value, allowing for dynamic transparency effects.</string>
+    <string name="bg_tooltip_color_func_opacity">Multiplies the opacity of the stroke by the specified value.</string>
     <string name="bg_tooltip_color_func_replace">Replaces the brush color with a specified color, ignoring the baseline color for this function\'s output.</string>
+    <string name="bg_tooltip_color_func_hue">Offsets the hue of the stroke by the specified value.</string>
+    <string name="bg_tooltip_color_func_saturation">Multiplies the saturation of the stroke by the specified value.</string>
+    <string name="bg_tooltip_color_func_luminosity">Offsets the luminosity of the stroke by the specified value.</string>
     <string name="bg_tooltip_color_func_default">Selects the type of color function to apply.</string>
     <!-- Tutorial Strings -->
     <string name="bg_tutorial_welcome_title">Welcome!</string>

--- a/app/src/test/java/com/example/cahier/developer/brushgraph/ui/TooltipsTest.kt
+++ b/app/src/test/java/com/example/cahier/developer/brushgraph/ui/TooltipsTest.kt
@@ -15,14 +15,14 @@
  */
 package com.example.cahier.developer.brushgraph.ui
 
+import com.example.cahier.R
 import com.example.cahier.developer.brushgraph.data.NodeData
 import ink.proto.BrushBehavior
 import ink.proto.BrushPaint
-import ink.proto.PredefinedEasingFunction as ProtoPredefinedEasingFunction
-import ink.proto.StepPosition as ProtoStepPosition
-import com.example.cahier.R
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import ink.proto.PredefinedEasingFunction as ProtoPredefinedEasingFunction
+import ink.proto.StepPosition as ProtoStepPosition
 
 class TooltipsTest {
 
@@ -38,19 +38,54 @@ class TooltipsTest {
             NodeData.ColorFunction(ink.proto.ColorFunction.getDefaultInstance()),
             NodeData.Coat(),
             NodeData.Family(),
-            
+
             // Behavior nodes
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setSourceNode(BrushBehavior.SourceNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setConstantNode(BrushBehavior.ConstantNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setNoiseNode(BrushBehavior.NoiseNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setToolTypeFilterNode(BrushBehavior.ToolTypeFilterNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setDampingNode(BrushBehavior.DampingNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setResponseNode(BrushBehavior.ResponseNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setBinaryOpNode(BrushBehavior.BinaryOpNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setInterpolationNode(BrushBehavior.InterpolationNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setIntegralNode(BrushBehavior.IntegralNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setTargetNode(BrushBehavior.TargetNode.getDefaultInstance()).build()),
-            NodeData.Behavior(BrushBehavior.Node.newBuilder().setPolarTargetNode(BrushBehavior.PolarTargetNode.getDefaultInstance()).build())
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setSourceNode(BrushBehavior.SourceNode.getDefaultInstance()).build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setConstantNode(BrushBehavior.ConstantNode.getDefaultInstance()).build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setNoiseNode(BrushBehavior.NoiseNode.getDefaultInstance()).build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setToolTypeFilterNode(BrushBehavior.ToolTypeFilterNode.getDefaultInstance())
+                    .build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setDampingNode(BrushBehavior.DampingNode.getDefaultInstance()).build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setResponseNode(BrushBehavior.ResponseNode.getDefaultInstance()).build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setBinaryOpNode(BrushBehavior.BinaryOpNode.getDefaultInstance()).build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setInterpolationNode(BrushBehavior.InterpolationNode.getDefaultInstance())
+                    .build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setIntegralNode(BrushBehavior.IntegralNode.getDefaultInstance()).build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setTargetNode(BrushBehavior.TargetNode.getDefaultInstance()).build()
+            ),
+            NodeData.Behavior(
+                BrushBehavior.Node.newBuilder()
+                    .setPolarTargetNode(BrushBehavior.PolarTargetNode.getDefaultInstance()).build()
+            )
         )
 
         for (node in nodes) {
@@ -65,7 +100,10 @@ class TooltipsTest {
         for (value in BrushBehavior.Source.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for Source.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for Source.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -75,7 +113,10 @@ class TooltipsTest {
         for (value in BrushBehavior.Target.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for Target.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for Target.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -95,7 +136,10 @@ class TooltipsTest {
         for (value in BrushPaint.TextureLayer.SizeUnit.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for SizeUnit.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for SizeUnit.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -105,7 +149,10 @@ class TooltipsTest {
         for (value in BrushPaint.TextureLayer.Origin.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for Origin.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for Origin.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -115,7 +162,10 @@ class TooltipsTest {
         for (value in BrushPaint.TextureLayer.Mapping.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for Mapping.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for Mapping.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -125,7 +175,10 @@ class TooltipsTest {
         for (value in BrushPaint.TextureLayer.BlendMode.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for BlendMode.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for BlendMode.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -135,7 +188,10 @@ class TooltipsTest {
         for (value in BrushPaint.SelfOverlap.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for SelfOverlap.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for SelfOverlap.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -145,7 +201,10 @@ class TooltipsTest {
         for (value in BrushBehavior.PolarTarget.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for PolarTarget.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for PolarTarget.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -155,7 +214,10 @@ class TooltipsTest {
         for (value in BrushBehavior.OutOfRange.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for OutOfRange.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for OutOfRange.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -165,7 +227,10 @@ class TooltipsTest {
         for (value in BrushBehavior.BinaryOp.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for BinaryOp.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for BinaryOp.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -175,7 +240,10 @@ class TooltipsTest {
         for (value in BrushBehavior.ProgressDomain.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for ProgressDomain.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for ProgressDomain.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -185,7 +253,10 @@ class TooltipsTest {
         for (value in BrushBehavior.Interpolation.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for Interpolation.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for Interpolation.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -195,7 +266,10 @@ class TooltipsTest {
         for (value in ProtoPredefinedEasingFunction.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for ProtoPredefinedEasingFunction.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for ProtoPredefinedEasingFunction.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -205,7 +279,10 @@ class TooltipsTest {
         for (value in ProtoStepPosition.values()) {
             if (value.name == "UNRECOGNIZED") continue
             val tooltip = value.getTooltip()
-            assertTrue("Tooltip should be unique for ProtoStepPosition.$value: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for ProtoStepPosition.$value: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 
@@ -218,19 +295,29 @@ class TooltipsTest {
         )
         for (modelResId in models) {
             val tooltip = getInputModelTooltip(modelResId)
-            assertTrue("Tooltip should be unique for InputModel.$modelResId: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for InputModel.$modelResId: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
+
     @Test
     fun colorFunctionTooltips_checked_areUnique() {
         val tooltips = mutableSetOf<Int>()
         val options = arrayOf(
-            R.string.bg_opacity_multiplier,
-            R.string.bg_replace_color
+            R.string.bg_target_opacity_multiplier,
+            R.string.bg_replace_color,
+            R.string.bg_target_saturation_multiplier,
+            R.string.bg_target_hue_offset,
+            R.string.bg_target_luminosity_offset
         )
         for (optionResId in options) {
             val tooltip = getColorFunctionTooltip(optionResId)
-            assertTrue("Tooltip should be unique for ColorFunction.$optionResId: $tooltip", tooltips.add(tooltip))
+            assertTrue(
+                "Tooltip should be unique for ColorFunction.$optionResId: $tooltip",
+                tooltips.add(tooltip)
+            )
         }
     }
 }


### PR DESCRIPTION
With `1.1.0-alpha04`, we got new color functions:

- Hue offset
- Saturation multiplier
- Luminosity offset

This change adds support for these color functions in brush graph, so we can load brushes that use these new features, and edit them. A lot of formatting changes also got picked up on save in `TooltipsTest.kt`.