### PR TITLE
Only support entry to graph UI for Brush Designer

### DIFF
--- a/app/src/main/java/com/example/cahier/core/navigation/CahierNavGraph.kt
+++ b/app/src/main/java/com/example/cahier/core/navigation/CahierNavGraph.kt
@@ -25,12 +25,11 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.example.cahier.core.ui.CahierTextureBitmapStore
-import com.example.cahier.developer.brushdesigner.ui.BrushDesignerScreen
+import com.example.cahier.developer.brushgraph.ui.BrushGraphScreen
 import com.example.cahier.features.drawing.DrawingCanvas
 import com.example.cahier.features.home.HomeDestination
 import com.example.cahier.features.home.HomePane
 import com.example.cahier.features.text.TextNoteCanvasScreen
-import com.example.cahier.developer.brushgraph.ui.BrushGraphScreen
 
 
 @OptIn(ExperimentalComposeApi::class)
@@ -38,7 +37,7 @@ import com.example.cahier.developer.brushgraph.ui.BrushGraphScreen
 fun CahierNavHost(
     navController: NavHostController,
     textureStore: CahierTextureBitmapStore,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     NavHost(
         navController = navController,
@@ -55,9 +54,6 @@ fun CahierNavHost(
                 },
                 navigateUp = {
                     navController.navigateUp()
-                },
-                navigateToBrushDesigner = {
-                    navController.navigate(BrushDesignerDestination.route)
                 },
                 navigateToBrushGraph = {
                     navController.navigate(BrushGraphDestination.route)
@@ -86,11 +82,6 @@ fun CahierNavHost(
                 navigateToBrushGraph = { navController.navigate(BrushGraphDestination.route) }
             )
         }
-        composable(route = BrushDesignerDestination.route) {
-            BrushDesignerScreen(
-                onNavigateUp = { navController.navigateUp() },
-            )
-        }
         composable(route = BrushGraphDestination.route) {
             BrushGraphScreen(
                 onNavigateUp = { navController.navigateUp() }
@@ -111,10 +102,6 @@ object DrawingCanvasDestination : NavigationDestination {
     override val route = "drawing_canvas"
     const val NOTE_ID_ARG = "noteId"
     val routeWithArgs = "$route/{$NOTE_ID_ARG}"
-}
-
-object BrushDesignerDestination : NavigationDestination {
-    override val route = "brush_designer"
 }
 
 object BrushGraphDestination : NavigationDestination {

--- a/app/src/main/java/com/example/cahier/features/home/CahierHomeScreen.kt
+++ b/app/src/main/java/com/example/cahier/features/home/CahierHomeScreen.kt
@@ -109,7 +109,7 @@ object HomeDestination : NavigationDestination {
 enum class AppDestinations(
     @param:StringRes val label: Int,
     @param:DrawableRes val icon: Int,
-    @param:StringRes val contentDescription: Int
+    @param:StringRes val contentDescription: Int,
 ) {
     Home(
         label = R.string.home,
@@ -133,7 +133,6 @@ enum class AppDestinations(
 fun HomePane(
     navigateToCanvas: (Long) -> Unit,
     navigateToDrawingCanvas: (Long) -> Unit,
-    navigateToBrushDesigner: () -> Unit = {},
     navigateToBrushGraph: () -> Unit = {},
     navigateUp: () -> Unit,
     modifier: Modifier = Modifier,
@@ -222,7 +221,6 @@ fun HomePane(
         selectedNoteUIState = selectedNoteUIState,
         navigateToCanvas = navigateToCanvas,
         navigateToDrawingCanvas = navigateToDrawingCanvas,
-        navigateToBrushDesigner = navigateToBrushDesigner,
         navigateToBrushGraph = navigateToBrushGraph,
         navigateUp = navigateUp
     )
@@ -243,9 +241,8 @@ private fun CahierNavigationSuite(
     selectedNoteUIState: CahierUiState,
     navigateToCanvas: (Long) -> Unit,
     navigateToDrawingCanvas: (Long) -> Unit,
-    navigateToBrushDesigner: () -> Unit,
     navigateToBrushGraph: () -> Unit,
-    navigateUp: () -> Unit
+    navigateUp: () -> Unit,
 ) {
     NavigationSuiteScaffold(
         modifier = modifier,
@@ -369,7 +366,6 @@ private fun CahierNavigationSuite(
 
                 AppDestinations.Settings -> {
                     SettingsScreen(
-                        navigateToBrushDesigner = navigateToBrushDesigner,
                         navigateToBrushGraph = navigateToBrushGraph,
                         modifier = Modifier.fillMaxSize()
                     )
@@ -416,7 +412,7 @@ private fun DetailPaneContent(
     note: Note,
     strokes: List<Stroke>,
     onClickToEdit: (Note) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     NoteDetail(
         note = note,

--- a/app/src/main/java/com/example/cahier/features/home/SettingsScreen.kt
+++ b/app/src/main/java/com/example/cahier/features/home/SettingsScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
@@ -58,14 +57,12 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    navigateToBrushDesigner: () -> Unit,
     navigateToBrushGraph: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: SettingsViewModel = hiltViewModel()
+    viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val isRoleAvailable by viewModel.isRoleAvailable.collectAsStateWithLifecycle()
     val isRoleHeld by viewModel.isRoleHeld.collectAsStateWithLifecycle()
-    val isUsingGraphUi by viewModel.isUsingGraphUi.collectAsStateWithLifecycle()
     LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
@@ -131,6 +128,7 @@ fun SettingsScreen(
                                     !isRoleAvailable -> stringResource(
                                         R.string.notes_role_not_available
                                     )
+
                                     isRoleHeld -> stringResource(R.string.notes_role_held)
                                     else -> stringResource(R.string.notes_role_not_held)
                                 },
@@ -175,8 +173,10 @@ fun SettingsScreen(
                                     style = MaterialTheme.typography.titleMedium
                                 )
                                 Text(
-                                    text = stringResource(R.string
-                                        .settings_developer_tools_description),
+                                    text = stringResource(
+                                        R.string
+                                            .settings_developer_tools_description
+                                    ),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
@@ -190,8 +190,10 @@ fun SettingsScreen(
                                     style = MaterialTheme.typography.bodyLarge
                                 )
                                 Text(
-                                    text = stringResource(R.string
-                                        .settings_brush_designer_description),
+                                    text = stringResource(
+                                        R.string
+                                            .settings_brush_designer_description
+                                    ),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
@@ -199,38 +201,11 @@ fun SettingsScreen(
 
                             FilledTonalButton(
                                 onClick = {
-                                    if (isUsingGraphUi) {
-                                        navigateToBrushGraph()
-                                    } else {
-                                        navigateToBrushDesigner()
-                                    }
+                                    navigateToBrushGraph()
                                 }
                             ) {
                                 Text(stringResource(R.string.settings_launch))
                             }
-                        }
-
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = stringResource(R.string.settings_graph_ui),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                                Text(
-                                    text = stringResource(R.string.settings_graph_description),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                            Switch(
-                                checked = isUsingGraphUi,
-                                onCheckedChange = { viewModel.setUsingGraphUi(it) },
-                                enabled = true
-                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/example/cahier/features/home/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/cahier/features/home/viewmodel/SettingsViewModel.kt
@@ -39,7 +39,7 @@ import javax.inject.Inject
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    @param: ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     private val _isRoleAvailable = MutableStateFlow(false)
@@ -47,14 +47,6 @@ class SettingsViewModel @Inject constructor(
 
     private val _isRoleHeld = MutableStateFlow(false)
     val isRoleHeld: StateFlow<Boolean> = _isRoleHeld.asStateFlow()
-
-    private val _isUsingGraphUi = MutableStateFlow(true)
-    val isUsingGraphUi: StateFlow<Boolean> = _isUsingGraphUi.asStateFlow()
-
-    fun setUsingGraphUi(isDefault: Boolean) {
-        _isUsingGraphUi.value = isDefault
-    }
-
     private val roleManager: RoleManager? by lazy {
         context.getSystemService(RoleManager::class.java)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,10 +270,8 @@
     <string name="settings_developer_tools">Developer Tools</string>
     <string name="settings_developer_tools_description">Experimental features and debugging tools.</string>
     <string name="settings_brush_designer_title">Ink Brush Designer</string>
-    <string name="settings_brush_designer_description">Create, test, and export custom brush families.</string>
+    <string name="settings_brush_designer_description">Create, test, and export custom brush families in a visual, node-based, graph UI.</string>
     <string name="settings_launch">Launch</string>
-    <string name="settings_graph_ui">Graph UI</string>
-    <string name="settings_graph_description">Visual, node-based brush designer</string>
 
     <!-- Brush Graph -->
     <string name="bg_name_texture">Name Texture</string>

--- a/app/src/test/java/com/example/cahier/ScreenshotTest.kt
+++ b/app/src/test/java/com/example/cahier/ScreenshotTest.kt
@@ -30,7 +30,6 @@ class ScreenshotTest {
         HomePane(
             navigateToCanvas = { _ -> },
             navigateToDrawingCanvas = { _ -> },
-            navigateToBrushDesigner = {},
             navigateToBrushGraph = {},
             navigateUp = {},
             homeScreenViewModel = fakeViewModel


### PR DESCRIPTION
Follow-up to https://github.com/android/cahier/pull/89, though they are independent and can be reviewed/merged asynchronously. Continuing work to remove `brushdesigner` in favor or `brushgraph`.

This removes the entry point for `brushdesigner` code, replacing it with an entry point that only routes to `brushgraph`. Note that "Ink Brush Designer" as a feature is still accessible and usable; we've just removed the option to *not* use the graph UI, since we are deprecating the columnar/tabbed UI of `brushdesigner` and only supporting the graph UI going forward. 